### PR TITLE
Add Ruby SDK support

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temporal-developer
-description: This skill should be used when the user asks to "create a Temporal workflow", "write a Temporal activity", "debug stuck workflow", "fix non-determinism error", "Temporal Python", "Temporal TypeScript", "workflow replay", "activity timeout", "signal workflow", "query workflow", "worker not starting", "activity keeps retrying", "Temporal heartbeat", "continue-as-new", "child workflow", "saga pattern", "workflow versioning", "durable execution", "reliable distributed systems", or mentions Temporal SDK development.
+description: This skill should be used when the user asks to "create a Temporal workflow", "write a Temporal activity", "debug stuck workflow", "fix non-determinism error", "Temporal Python", "Temporal TypeScript", "Temporal Ruby", "workflow replay", "activity timeout", "signal workflow", "query workflow", "worker not starting", "activity keeps retrying", "Temporal heartbeat", "continue-as-new", "child workflow", "saga pattern", "workflow versioning", "durable execution", "reliable distributed systems", or mentions Temporal SDK development.
 version: 1.0.0
 ---
 
@@ -8,7 +8,7 @@ version: 1.0.0
 
 ## Overview
 
-Temporal is a durable execution platform that makes workflows survive failures automatically. This skill provides guidance for building Temporal applications in Python and TypeScript.
+Temporal is a durable execution platform that makes workflows survive failures automatically. This skill provides guidance for building Temporal applications in Python, TypeScript, and Ruby.
 
 ## Core Architecture
 
@@ -92,6 +92,7 @@ Once you've downloaded the file, extract the downloaded archive and add the temp
 1. First, read the getting started guide for the language you are working in:
     - Python -> read `references/python/python.md`
     - TypeScript -> read `references/typescript/typescript.md`
+    - Ruby -> read `references/ruby/ruby.md`
 2. Second, read appropriate `core` and language-specific references for the task at hand.
 
 

--- a/references/core/determinism.md
+++ b/references/core/determinism.md
@@ -80,6 +80,7 @@ Each Temporal SDK language provides a protection mechanism to make it easier to 
 
 - Python: The Python SDK runs workflows in a sandbox that intercepts and aborts non-deterministic calls at runtime.
 - TypeScript: The TypeScript SDK runs workflows in an isolated V8 sandbox, intercepting many common sources of non-determinism and replacing them automatically with deterministic variants.
+- Ruby: The Ruby SDK uses Illegal Call Tracing (via `TracePoint`) to detect forbidden method calls at runtime on the workflow fiber, combined with a Durable Fiber Scheduler that makes fiber operations deterministic.
 
 
 ## Detecting Non-Determinism

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -1,0 +1,191 @@
+# Ruby SDK Advanced Features
+
+## Schedules
+
+Create recurring workflow executions with `Temporalio::Client::Schedule`.
+
+```ruby
+require 'temporalio/client'
+
+# Create a schedule
+schedule_id = 'daily-report'
+client.create_schedule(
+  schedule_id,
+  Temporalio::Client::Schedule.new(
+    action: Temporalio::Client::Schedule::Action::StartWorkflow.new(
+      DailyReportWorkflow,
+      id: 'daily-report',
+      task_queue: 'reports'
+    ),
+    spec: Temporalio::Client::Schedule::Spec.new(
+      intervals: [
+        Temporalio::Client::Schedule::Spec::Interval.new(every: 86_400) # 1 day in seconds
+      ]
+    )
+  )
+)
+
+# Manage schedules
+handle = client.schedule_handle(schedule_id)
+handle.pause(note: 'Maintenance window')
+handle.unpause
+handle.trigger
+handle.delete
+```
+
+## Async Activity Completion
+
+For activities that complete asynchronously (e.g., human tasks, external callbacks).
+
+```ruby
+class RequestApproval < Temporalio::Activity::Definition
+  def execute(request_id)
+    # Get task token for async completion
+    task_token = Temporalio::Activity::Context.current.info.task_token
+
+    # Store task token for later completion (e.g., in database)
+    store_task_token(request_id, task_token)
+
+    # Signal that this activity completes asynchronously
+    Temporalio::Activity::Context.current.raise_complete_async
+  end
+end
+
+# Later, complete the activity from another process
+client = Temporalio::Client.connect('localhost:7233')
+task_token = get_task_token(request_id)
+handle = client.async_activity_handle(task_token: task_token)
+
+if approved
+  handle.complete('approved')
+else
+  handle.fail(Temporalio::Error::ApplicationError.new('Rejected'))
+end
+```
+
+If you configure a `heartbeat_timeout:` on the activity, the external completer is responsible for sending heartbeats via the async handle. If you do NOT set a `heartbeat_timeout`, no heartbeats are required.
+
+## Worker Tuning
+
+Configure worker performance settings.
+
+```ruby
+worker = Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-queue',
+  workflows: [MyWorkflow],
+  activities: [MyActivity],
+  max_concurrent_workflow_tasks: 100,
+  max_concurrent_activities: 100
+)
+worker.run
+```
+
+## Workflow Failure Exception Types
+
+Control which exceptions cause workflow failure vs workflow task failure (which Temporal retries automatically).
+
+### Per-Workflow Configuration
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  # Class method approach
+  def self.workflow_failure_exception_type
+    MyCustomError
+  end
+
+  def execute
+    raise MyCustomError, 'This fails the workflow, not just the task'
+  end
+end
+```
+
+### Worker-Level Configuration
+
+```ruby
+Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-queue',
+  workflows: [MyWorkflow],
+  workflow_failure_exception_types: [MyCustomError]
+)
+```
+
+**Tips:**
+- Set to `[Exception]` in tests so any unhandled exception fails the workflow immediately rather than retrying the workflow task forever. Surfaces bugs faster.
+- Include `Temporalio::Workflow::NondeterminismError` to fail the workflow instead of leaving it in a retrying state on non-determinism errors.
+
+## Activity Concurrency and Executors
+
+Ruby uses `Temporalio::Worker::ActivityExecutor::ThreadPool` by default. Activities run in a thread pool.
+
+```ruby
+# Default: activities run in thread pool
+worker = Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-queue',
+  workflows: [MyWorkflow],
+  activities: [MyActivity],
+  activity_executors: {
+    default: Temporalio::Worker::ActivityExecutor::ThreadPool.new(max_threads: 20)
+  }
+)
+```
+
+Fiber-based execution is also possible for IO-bound activities using Ruby's fiber scheduler.
+
+## Rails Integration
+
+### ActiveRecord Considerations
+
+Never pass ActiveRecord models directly to Temporal workflows or activities. Serialize to plain data structures.
+
+```ruby
+# BAD - Passing AR model
+client.execute_workflow(
+  ProcessOrderWorkflow,
+  Order.find(42),  # Don't pass AR objects!
+  id: 'order-42',
+  task_queue: 'orders'
+)
+
+# GOOD - Pass serializable data
+client.execute_workflow(
+  ProcessOrderWorkflow,
+  { id: 42, total: order.total, status: order.status },
+  id: 'order-42',
+  task_queue: 'orders'
+)
+```
+
+### Zeitwerk and Autoloading
+
+Rails uses Zeitwerk for autoloading. Workflow and activity classes must be loadable by Zeitwerk or explicitly required.
+
+```ruby
+# In config/initializers/temporal.rb or similar
+# Eager load Temporal classes so they're available to the worker
+Rails.application.config.after_initialize do
+  Dir[Rails.root.join('app/workflows/**/*.rb')].each { |f| require f }
+  Dir[Rails.root.join('app/activities/**/*.rb')].each { |f| require f }
+end
+```
+
+### Forking Considerations
+
+If using a forking server (Puma, Unicorn), workers must be created **after** the fork. Connections established before fork are not safe to share across processes.
+
+```ruby
+# In Puma config (puma.rb)
+on_worker_boot do
+  # Create Temporal client and worker AFTER fork
+  client = Temporalio::Client.connect('localhost:7233')
+  worker = Temporalio::Worker.new(
+    client: client,
+    task_queue: 'my-queue',
+    workflows: [MyWorkflow],
+    activities: [MyActivity]
+  )
+  Thread.new { worker.run }
+end
+```

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -78,10 +78,15 @@ worker = Temporalio::Worker.new(
   workflows: [MyWorkflow],
   activities: [MyActivity],
   max_concurrent_workflow_tasks: 100,
-  max_concurrent_activities: 100
+  max_concurrent_activities: 100,
+  # Grace period (seconds) after shutdown is requested before in-progress
+  # activities are canceled. Defaults to 0 (cancel immediately on shutdown).
+  graceful_shutdown_period: 30
 )
 worker.run
 ```
+
+On shutdown the worker stops polling for new tasks and cancels the `worker_shutdown_cancellation` on each running activity's context. After `graceful_shutdown_period` seconds it then issues actual cancellation to any still-running activities. The worker will not finish shutting down until all in-progress activities complete, so activities that ignore cancellation can block shutdown indefinitely.
 
 ## Workflow Init
 

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -177,7 +177,7 @@ If using a forking server (Puma, Unicorn), workers must be created **after** the
 
 ```ruby
 # In Puma config (puma.rb)
-on_worker_boot do
+before_worker_boot do
   # Create Temporal client and worker AFTER fork
   client = Temporalio::Client.connect('localhost:7233')
   worker = Temporalio::Worker.new(

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -77,8 +77,12 @@ worker = Temporalio::Worker.new(
   task_queue: 'my-queue',
   workflows: [MyWorkflow],
   activities: [MyActivity],
-  max_concurrent_workflow_tasks: 100,
-  max_concurrent_activities: 100,
+  # Max concurrent execution slots (default 100 each): how many workflow tasks
+  # and activities run at once on this worker.
+  tuner: Temporalio::Worker::Tuner.create_fixed(
+    workflow_slots: 100,
+    activity_slots: 100
+  ),
   # Grace period (seconds) after shutdown is requested before in-progress
   # activities are canceled. Defaults to 0 (cancel immediately on shutdown).
   graceful_shutdown_period: 30

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -92,7 +92,7 @@ worker.run
 
 On shutdown the worker stops polling for new tasks and cancels the `worker_shutdown_cancellation` on each running activity's context. After `graceful_shutdown_period` seconds it then issues actual cancellation to any still-running activities. The worker will not finish shutting down until all in-progress activities complete, so activities that ignore cancellation can block shutdown indefinitely.
 
-## Workflow Init
+## Workflow Init Decorator
 
 Always initialize workflow state before signals/updates arrive. Signal and Update handlers can run *before* the main `execute` method -- for example with Signal-with-Start, when the Task Queue is backlogged, or right after continue-as-new -- so a handler may otherwise read uninitialized instance variables.
 

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -37,6 +37,8 @@ handle.delete
 
 For activities that complete asynchronously (e.g., human tasks, external callbacks).
 
+**Note:** If the external system that completes the asynchronous action can reliably be trusted to do the task and Signal back with the result, and it doesn't need to Heartbeat or receive Cancellation, then consider using **signals** instead.
+
 ```ruby
 class RequestApproval < Temporalio::Activity::Definition
   def execute(request_id)

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -83,6 +83,42 @@ worker = Temporalio::Worker.new(
 worker.run
 ```
 
+## Workflow Init
+
+Always initialize workflow state before signals/updates arrive. Signal and Update handlers can run *before* the main `execute` method -- for example with Signal-with-Start, when the Task Queue is backlogged, or right after continue-as-new -- so a handler may otherwise read uninitialized instance variables.
+
+Normally `initialize` must accept no required arguments. If you place the `workflow_init` class method directly above `initialize`, the constructor receives the same workflow arguments that `execute` receives (the same input the Client sent). It is guaranteed to run before any handler.
+
+```ruby
+class GreetingWorkflow < Temporalio::Workflow::Definition
+  workflow_init
+  def initialize(input)
+    # Runs before any signal/update handler
+    @name_with_title = "Sir #{input['name']}"
+    @title_has_been_checked = false
+  end
+
+  def execute(input)
+    Temporalio::Workflow.wait_condition { @title_has_been_checked }
+    "Hello, #{@name_with_title}"
+  end
+
+  workflow_update
+  def check_title_validity
+    # Guaranteed to see workflow input, since initialize ran first
+    valid = Temporalio::Workflow.execute_activity(
+      CheckTitleValidityActivity,
+      @name_with_title,
+      start_to_close_timeout: 100
+    )
+    @title_has_been_checked = true
+    valid
+  end
+end
+```
+
+`initialize` (with `workflow_init`) and `execute` must have the same parameters with the same types. You cannot make blocking calls (activities, sleeps, etc.) from `initialize`.
+
 ## Workflow Failure Exception Types
 
 Control which exceptions cause workflow failure vs workflow task failure (which Temporal retries automatically).

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -160,7 +160,7 @@ client.execute_workflow(
 
 ### Zeitwerk and Autoloading
 
-Rails uses Zeitwerk for autoloading. Workflow and activity classes must be loadable by Zeitwerk or explicitly required.
+Rails autoloading can result in unexpected I/O during replay. `config.eager_load` must be enabled or Workflows must explicitly require code dependencies before they are executed.
 
 ```ruby
 # In config/initializers/temporal.rb or similar

--- a/references/ruby/advanced-features.md
+++ b/references/ruby/advanced-features.md
@@ -160,15 +160,24 @@ client.execute_workflow(
 
 ### Zeitwerk and Autoloading
 
-Rails autoloading can result in unexpected I/O during replay. `config.eager_load` must be enabled or Workflows must explicitly require code dependencies before they are executed.
+Rails autoloading can result in unexpected I/O during replay. `config.eager_load` must be enabled or Workflows must explicitly require code dependencies before they are executed. Usually the easiest place to do that is when starting the worker, and requiring all activities and workflows that the worker needs *before* starting the worker. For example:
 
 ```ruby
-# In config/initializers/temporal.rb or similar
-# Eager load Temporal classes so they're available to the worker
-Rails.application.config.after_initialize do
-  Dir[Rails.root.join('app/workflows/**/*.rb')].each { |f| require f }
-  Dir[Rails.root.join('app/activities/**/*.rb')].each { |f| require f }
-end
+require "temporal_client"
+require "temporalio/worker"
+require "workflows/shopping_cart_activities.rb"
+require "workflows/shopping_cart_workflow.rb"
+
+worker = Temporalio::Worker.new(
+  client: TemporalClient.instance,
+  task_queue: TemporalClient.task_queue,
+  activities: [
+    Workflows::ShoppingCartActivities::FetchProducts,
+    ...
+  ],
+  workflows: [ Workflows::ShoppingCartWorkflow ]
+)
+worker.run
 ```
 
 ### Forking Considerations

--- a/references/ruby/data-handling.md
+++ b/references/ruby/data-handling.md
@@ -17,40 +17,39 @@ Note: symbol keys become strings on deserialization. `create_additions: true` by
 
 ## ActiveModel Integration
 
-Use the `ActiveModelJSONSupport` mixin for custom model classes:
+Use the `ActiveModelJSONSupport` mixin to make ActiveModel objects work with Temporal's JSON serialization:
 
 ```ruby
 module ActiveModelJSONSupport
-  def as_json(_options = {})
-    { JSON.create_id => self.class.name }.merge(instance_variables.each_with_object({}) do |var, hash|
-      hash[var.to_s.delete('@')] = instance_variable_get(var)
-    end)
-  end
+  extend ActiveSupport::Concern
+  include ActiveModel::Serializers::JSON
 
-  def to_json(*args)
-    as_json.to_json(*args)
-  end
+  included do
+    def as_json(*)
+      super.merge(::JSON.create_id => self.class.name)
+    end
 
-  def self.included(base)
-    base.define_method(:json_create) do |hash|
-      obj = base.new
-      hash.each do |key, value|
-        next if key == JSON.create_id
-        obj.instance_variable_set("@#{key}", value)
-      end
-      obj
+    def to_json(*args)
+      as_json.to_json(*args)
+    end
+
+    def self.json_create(object)
+      object = object.dup
+      object.delete(::JSON.create_id)
+      new(**object.symbolize_keys)
     end
   end
 end
+```
 
-class MyModel
+Include it in any ActiveModel class to make it serializable by Temporal:
+
+```ruby
+class OrderInput
+  include ActiveModel::Model
   include ActiveModelJSONSupport
-  attr_accessor :name, :value
 
-  def initialize(name: nil, value: nil)
-    @name = name
-    @value = value
-  end
+  attr_accessor :order_id, :items, :total
 end
 ```
 
@@ -151,7 +150,7 @@ Temporalio::Workflow.upsert_search_attributes({ key => 'new-value' })
 Query workflows:
 
 ```ruby
-client.list_workflows(filter: "CustomerId = 'customer-123'")
+client.list_workflows("CustomerId = 'customer-123'")
 ```
 
 ## Workflow Memo

--- a/references/ruby/data-handling.md
+++ b/references/ruby/data-handling.md
@@ -1,0 +1,192 @@
+# Ruby SDK Data Handling
+
+## Overview
+
+Data converters serialize and deserialize workflow/activity inputs and outputs. The `Temporalio::Converters` module provides the conversion pipeline.
+
+## Default Data Converter
+
+The default converter handles types in this order:
+
+1. `nil` - null payload
+2. Bytes - `String` with `ASCII_8BIT` encoding
+3. Protobuf - objects implementing `Google::Protobuf::MessageExts`
+4. JSON - everything else, via Ruby's `JSON` module
+
+Note: symbol keys become strings on deserialization. `create_additions: true` by default.
+
+## ActiveModel Integration
+
+Use the `ActiveModelJSONSupport` mixin for custom model classes:
+
+```ruby
+module ActiveModelJSONSupport
+  def as_json(_options = {})
+    { JSON.create_id => self.class.name }.merge(instance_variables.each_with_object({}) do |var, hash|
+      hash[var.to_s.delete('@')] = instance_variable_get(var)
+    end)
+  end
+
+  def to_json(*args)
+    as_json.to_json(*args)
+  end
+
+  def self.included(base)
+    base.define_method(:json_create) do |hash|
+      obj = base.new
+      hash.each do |key, value|
+        next if key == JSON.create_id
+        obj.instance_variable_set("@#{key}", value)
+      end
+      obj
+    end
+  end
+end
+
+class MyModel
+  include ActiveModelJSONSupport
+  attr_accessor :name, :value
+
+  def initialize(name: nil, value: nil)
+    @name = name
+    @value = value
+  end
+end
+```
+
+## Custom Data Converter
+
+```ruby
+converter = Temporalio::Converters::DataConverter.new(
+  payload_converter: my_payload_converter,
+  payload_codec: my_payload_codec,
+  failure_converter: my_failure_converter
+)
+
+client = Temporalio::Client.connect(
+  'localhost:7233',
+  'default',
+  data_converter: converter
+)
+```
+
+## Converter Hints
+
+Ruby-specific feature for guiding deserialization to the correct type:
+
+```ruby
+class MyWorkflow
+  workflow_arg_hint MyClass
+  workflow_result_hint MyClass
+
+  workflow_update :my_update, arg_hints: [MyClass]
+
+  def execute(input)
+    # input is deserialized as MyClass
+  end
+end
+```
+
+Custom converters use these hints to know the target deserialization type.
+
+## Payload Encryption
+
+Implement a `PayloadCodec` with `encode` and `decode`:
+
+```ruby
+class EncryptionCodec
+  def encode(payloads)
+    payloads.map { |p| encrypt(p) }
+  end
+
+  def decode(payloads)
+    payloads.map { |p| decrypt(p) }
+  end
+
+  private
+
+  def encrypt(payload)
+    # encryption logic
+  end
+
+  def decrypt(payload)
+    # decryption logic
+  end
+end
+
+converter = Temporalio::Converters::DataConverter.new(
+  payload_codec: EncryptionCodec.new
+)
+```
+
+## Search Attributes
+
+Define a search attribute key:
+
+```ruby
+key = Temporalio::SearchAttributes::Key.new(
+  'CustomerId',
+  Temporalio::SearchAttributes::IndexedValueType::KEYWORD
+)
+```
+
+Set at workflow start:
+
+```ruby
+client.start_workflow(
+  MyWorkflow,
+  'arg',
+  id: 'wf-1',
+  task_queue: 'my-queue',
+  search_attributes: Temporalio::SearchAttributes.new({ key => 'customer-123' })
+)
+```
+
+Upsert from a workflow:
+
+```ruby
+Temporalio::Workflow.upsert_search_attributes({ key => 'new-value' })
+```
+
+Query workflows:
+
+```ruby
+client.list_workflows(filter: "CustomerId = 'customer-123'")
+```
+
+## Workflow Memo
+
+Set at workflow start:
+
+```ruby
+client.start_workflow(
+  MyWorkflow,
+  'arg',
+  id: 'wf-1',
+  task_queue: 'my-queue',
+  memo: { 'region' => 'us-east', 'priority' => 'high' }
+)
+```
+
+Read from within a workflow:
+
+```ruby
+region = Temporalio::Workflow.memo['region']
+```
+
+## Deterministic APIs for Values
+
+Use these instead of standard Ruby equivalents inside workflows:
+
+```ruby
+Temporalio::Workflow.uuid       # deterministic UUID
+Temporalio::Workflow.random     # deterministic random number
+Temporalio::Workflow.now        # deterministic current time
+```
+
+## Best Practices
+
+- Use dedicated model classes for Temporal data, not ActiveRecord models.
+- Keep payloads small; store large data externally and pass references.
+- Encrypt sensitive data with a `PayloadCodec`.
+- Use `Temporalio::Workflow.uuid`, `.random`, and `.now` inside workflows for determinism.

--- a/references/ruby/data-handling.md
+++ b/references/ruby/data-handling.md
@@ -53,7 +53,7 @@ class OrderInput
 end
 ```
 
-## Custom Data Converter
+## Custom Data Conversion
 
 ```ruby
 converter = Temporalio::Converters::DataConverter.new(
@@ -147,7 +147,7 @@ Upsert from a workflow:
 Temporalio::Workflow.upsert_search_attributes({ key => 'new-value' })
 ```
 
-Query workflows:
+### Querying Workflows by Search Attributes
 
 ```ruby
 client.list_workflows("CustomerId = 'customer-123'")

--- a/references/ruby/determinism-protection.md
+++ b/references/ruby/determinism-protection.md
@@ -1,0 +1,157 @@
+# Ruby Workflow Determinism Protection
+
+## Overview
+
+The Ruby SDK uses two mechanisms to enforce workflow determinism:
+
+1. **Illegal Call Tracing** -- `TracePoint`-based interception of forbidden method calls on the workflow fiber.
+2. **Durable Fiber Scheduler** -- a custom `Fiber::Scheduler` that makes fiber operations deterministic.
+
+This differs from Python's sandbox (`SandboxedWorkflowRunner`) and TypeScript's V8 isolate sandbox. Ruby's approach is runtime tracing, not code isolation.
+
+## How Illegal Call Tracing Works
+
+A `TracePoint` is installed on the workflow fiber thread. On every `:call` and `:c_call` event, the SDK checks the receiver class and method name against a configurable set of illegal calls.
+
+```ruby
+# Internally, the SDK does something like:
+TracePoint.new(:call, :c_call) do |tp|
+  if illegal?(tp.defined_class, tp.method_id)
+    raise Temporalio::Workflow::NondeterminismError,
+      "Illegal call: #{tp.defined_class}##{tp.method_id}"
+  end
+end
+```
+
+Key behaviors:
+
+- Raises `Temporalio::Workflow::NondeterminismError` on violation.
+- Detects transitive calls -- a gem calling `IO.read` deep in its internals will still be caught.
+- Only active on the workflow fiber, not on activity threads or other fibers.
+
+## Forbidden Operations
+
+Default forbidden operations:
+
+- `Kernel.sleep` -- use `Temporalio::Workflow.sleep`
+- `Time.now` (no args) -- use `Temporalio::Workflow.now`
+- `Thread.new` -- not allowed in workflows
+- `IO.*` -- all IO class methods (`IO.read`, `IO.write`, `IO.pipe`, etc.)
+- `Socket.*` -- all socket operations
+- `Net::HTTP.*` -- all HTTP client calls
+- `Random.*` -- use `Temporalio::Workflow.random`
+- `SecureRandom.*` -- use `Temporalio::Workflow.uuid` for UUIDs
+- `Timeout.timeout` -- use `Temporalio::Workflow.sleep` with cancellation
+
+Note: `Time.new('2000-12-31')` with arguments IS deterministic and allowed. Only `Time.now` (wall-clock) is forbidden.
+
+## Durable Fiber Scheduler
+
+The SDK provides a custom `Fiber::Scheduler` implementation that makes fiber primitives deterministic within the workflow.
+
+- `Kernel.sleep` and `Mutex` technically work under the durable scheduler but are **disabled by default** via illegal call tracing to prevent accidental misuse.
+- `Temporalio::Workflow.sleep` and `Temporalio::Workflow.wait_condition` are the correct alternatives.
+
+```ruby
+# Correct: deterministic sleep
+Temporalio::Workflow.sleep(30)
+
+# Correct: wait for a condition
+Temporalio::Workflow.wait_condition { @order_confirmed }
+```
+
+## Disabling Illegal Call Tracing
+
+Use `Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled` when third-party code is known safe:
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  def execute
+    # Third-party gem that does harmless Time.now internally
+    result = Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled do
+      SomeGem.format_data(input)
+    end
+    result
+  end
+end
+```
+
+The block disables tracing only for its duration. Keep it as narrow as possible.
+
+## Customizing Illegal Calls
+
+Pass `illegal_workflow_calls:` to `Temporalio::Worker.new`:
+
+```ruby
+worker = Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-queue',
+  workflows: [MyWorkflow],
+  illegal_workflow_calls: Temporalio::Worker.default_illegal_workflow_calls.merge(
+    'MyInternalClass' => :all,
+    'AnotherClass' => { dangerous_method: true }
+  )
+)
+```
+
+Default set available via:
+
+```ruby
+Temporalio::Worker.default_illegal_workflow_calls
+# => { 'Kernel' => { sleep: true }, 'IO' => :all, ... }
+```
+
+Hash format:
+
+- `{ 'ClassName' => :all }` -- block all methods on the class.
+- `{ 'ClassName' => { method_name: true } }` -- block specific methods.
+
+## Common Issues
+
+### Third-party gems triggering NondeterminismError
+
+Gems that call `IO`, `Time.now`, or `Socket` internally will trigger errors even if you don't call those methods directly.
+
+**Fix 1:** Wrap in `illegal_call_tracing_disabled`:
+
+```ruby
+Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled do
+  ThirdPartyGem.safe_pure_computation(data)
+end
+```
+
+**Fix 2:** For code that needs IO (e.g., reading a config file), use `io_enabled`:
+
+```ruby
+Temporalio::Workflow::Unsafe.io_enabled do
+  config = YAML.load_file('config.yml')
+end
+```
+
+**Fix 3:** Combine with replay check for side effects:
+
+```ruby
+unless Temporalio::Workflow::Unsafe.replaying?
+  Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled do
+    MetricsClient.increment('workflow.started')
+  end
+end
+```
+
+### Durable scheduler conflicts
+
+If a gem requires its own fiber scheduler behavior, disable the durable scheduler for that block:
+
+```ruby
+Temporalio::Workflow::Unsafe.durable_scheduler_disabled do
+  some_fiber_aware_gem.call
+end
+```
+
+## Best Practices
+
+- Use `Temporalio::Workflow.sleep`, `.now`, `.random`, `.uuid`, `.logger` for all workflow-level operations.
+- Never perform IO, network calls, or file access in workflow code -- delegate to activities.
+- Use `illegal_call_tracing_disabled` sparingly and only when you are certain the code is deterministic.
+- Wrap side-effect-only code in `unless Temporalio::Workflow::Unsafe.replaying?` to avoid duplicate emissions during replay.
+- Prefer activities over `io_enabled` blocks -- activities have proper retry, timeout, and heartbeat semantics.

--- a/references/ruby/determinism-protection.md
+++ b/references/ruby/determinism-protection.md
@@ -42,23 +42,9 @@ Default forbidden operations:
 - `Random.*` -- use `Temporalio::Workflow.random`
 - `SecureRandom.*` -- use `Temporalio::Workflow.uuid` for UUIDs
 - `Timeout.timeout` -- use `Temporalio::Workflow.sleep` with cancellation
+- `Mutex` -- use `Temporalio::Workflow::Mutex`
 
 Note: `Time.new('2000-12-31')` with arguments IS deterministic and allowed. Only `Time.now` (wall-clock) is forbidden.
-
-## Durable Fiber Scheduler
-
-The SDK provides a custom `Fiber::Scheduler` implementation that makes fiber primitives deterministic within the workflow.
-
-- `Kernel.sleep` and `Mutex` technically work under the durable scheduler but are **disabled by default** via illegal call tracing to prevent accidental misuse.
-- `Temporalio::Workflow.sleep` and `Temporalio::Workflow.wait_condition` are the correct alternatives.
-
-```ruby
-# Correct: deterministic sleep
-Temporalio::Workflow.sleep(30)
-
-# Correct: wait for a condition
-Temporalio::Workflow.wait_condition { @order_confirmed }
-```
 
 ## Disabling Illegal Call Tracing
 

--- a/references/ruby/determinism-protection.md
+++ b/references/ruby/determinism-protection.md
@@ -29,7 +29,7 @@ Key behaviors:
 - Detects transitive calls -- a gem calling `IO.read` deep in its internals will still be caught.
 - Only active on the workflow fiber, not on activity threads or other fibers.
 
-## Forbidden Operations
+## Forbidden Operations in Workflows
 
 Default forbidden operations:
 

--- a/references/ruby/determinism-protection.md
+++ b/references/ruby/determinism-protection.md
@@ -96,17 +96,11 @@ Hash format:
 
 ### Third-party gems triggering NondeterminismError
 
-Gems that call `IO`, `Time.now`, or `Socket` internally will trigger errors even if you don't call those methods directly.
+Gems that call `IO`, `Time.now`, or `Socket` internally will trigger errors even if you don't call those methods directly. The correct fix is context-dependent and requires understanding and possibly debugging of the situation.
 
-**Fix 1:** Wrap in `illegal_call_tracing_disabled`:
+**Fix 1:** The call to a gem genuinely is doing IO, side effects, or other non-deterministic things. Then just like with other Temporal Workflow code, it should be moved into an activity.
 
-```ruby
-Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled do
-  ThirdPartyGem.safe_pure_computation(data)
-end
-```
-
-**Fix 2:** For code that needs IO (e.g., reading a config file), use `io_enabled`:
+**Fix 2:** Escape hatch: for code that needs IO to run within the workflow, use `io_enabled`. You should very seriously consider why IO is needed in the workflow and not in an activity. If you use this escape hatch to create non-determinism issues, you might later face non-determinism errors.
 
 ```ruby
 Temporalio::Workflow::Unsafe.io_enabled do
@@ -114,13 +108,11 @@ Temporalio::Workflow::Unsafe.io_enabled do
 end
 ```
 
-**Fix 3:** Combine with replay check for side effects:
+**Fix 3:** Escape hatch: for code that triggers the illegal call tracing but doesn't cause actual non-determinism issues, you can disable `illegal_call_tracing_disabled`. Again, you must be sure that you are semantically correct that there is no non-determinism involved.
 
 ```ruby
-unless Temporalio::Workflow::Unsafe.replaying?
-  Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled do
-    MetricsClient.increment('workflow.started')
-  end
+Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled do
+  ThirdPartyGem.safe_pure_computation(data)
 end
 ```
 

--- a/references/ruby/determinism-protection.md
+++ b/references/ruby/determinism-protection.md
@@ -42,7 +42,7 @@ Default forbidden operations:
 - `Random.*` -- use `Temporalio::Workflow.random`
 - `SecureRandom.*` -- use `Temporalio::Workflow.uuid` for UUIDs
 - `Timeout.timeout` -- use `Temporalio::Workflow.sleep` with cancellation
-- `Mutex` -- use `Temporalio::Workflow::Mutex`
+- `Mutex` / `synchronize` -- use an explicit `Temporalio::Workflow::Mutex`
 
 Note: `Time.new('2000-12-31')` with arguments IS deterministic and allowed. Only `Time.now` (wall-clock) is forbidden.
 

--- a/references/ruby/determinism.md
+++ b/references/ruby/determinism.md
@@ -1,0 +1,61 @@
+# Ruby SDK Determinism
+
+## Overview
+
+The Ruby SDK enforces workflow determinism through **Illegal Call Tracing** (via `TracePoint`) and a **Durable Fiber Scheduler**. This is not a sandbox like Python's `SandboxedWorkflowRunner`; instead, it intercepts illegal calls at runtime on the workflow fiber.
+
+## Why Determinism Matters: History Replay
+
+Temporal re-executes workflow code from the beginning on recovery (worker restart, continue-as-new, etc.). Commands already recorded in history are matched against replayed commands. If the code produces different commands on replay, the workflow fails with a non-determinism error.
+
+All workflow code must therefore be deterministic: same input and history must produce the same sequence of commands every time.
+
+## SDK Protection: Illegal Call Tracing
+
+The Ruby SDK installs a `TracePoint` on the workflow fiber thread. Every method call is checked against a configurable set of illegal calls. If a forbidden method is invoked, the SDK raises `Temporalio::Workflow::NondeterminismError`.
+
+Configuration is via the `illegal_workflow_calls` parameter on `Temporalio::Worker.new`. The default set is available at:
+
+```ruby
+Temporalio::Worker.default_illegal_workflow_calls
+```
+
+## Forbidden Operations
+
+The following are forbidden inside workflow code by default:
+
+- `Kernel.sleep` -- blocks the fiber non-deterministically
+- `Time.now` (without args) -- returns wall-clock time
+- `Thread.new` -- spawns non-deterministic OS threads
+- `IO` operations (`IO.read`, `IO.write`, `File.open`, etc.)
+- `Random.rand` / `SecureRandom` -- non-deterministic randomness
+- `Process` calls (`Process.spawn`, `Process.exec`, etc.)
+- Network calls (`Net::HTTP`, `Socket`, etc.)
+
+## Safe Builtin Alternatives
+
+| Forbidden | Safe Alternative |
+|-----------|------------------|
+| `Kernel.sleep(n)` | `Temporalio::Workflow.sleep(n)` |
+| `Time.now` | `Temporalio::Workflow.now` |
+| `Random.rand` / `SecureRandom` | `Temporalio::Workflow.random.rand(100)` |
+| `SecureRandom.uuid` | `Temporalio::Workflow.uuid` |
+| `Logger.new` / `puts` | `Temporalio::Workflow.logger.info(...)` |
+
+## Testing Replay Compatibility
+
+Use `Temporalio::Worker::WorkflowReplayer` to verify that workflow code is replay-compatible against recorded histories. See `testing.md` for details.
+
+```ruby
+replayer = Temporalio::Worker::WorkflowReplayer.new(
+  workflows: [MyWorkflow]
+)
+replayer.replay_workflow(workflow_history)
+```
+
+## Best Practices
+
+- Use `Temporalio::Workflow.sleep`, `.now`, `.random`, `.uuid`, `.logger` instead of stdlib equivalents.
+- Delegate all I/O, network calls, and side effects to activities.
+- Test with `WorkflowReplayer` against saved histories before deploying workflow changes.
+- Use `Temporalio::Workflow.logger` for all logging inside workflows -- it is replay-aware and suppresses duplicate logs during replay.

--- a/references/ruby/determinism.md
+++ b/references/ruby/determinism.md
@@ -31,6 +31,7 @@ The following are forbidden inside workflow code by default:
 - `Random.rand` / `SecureRandom` -- non-deterministic randomness
 - `Process` calls (`Process.spawn`, `Process.exec`, etc.)
 - Network calls (`Net::HTTP`, `Socket`, etc.)
+- `Mutex` / `synchronize`
 
 ## Safe Builtin Alternatives
 
@@ -41,6 +42,7 @@ The following are forbidden inside workflow code by default:
 | `Random.rand` / `SecureRandom` | `Temporalio::Workflow.random.rand(100)` |
 | `SecureRandom.uuid` | `Temporalio::Workflow.uuid` |
 | `Logger.new` / `puts` | `Temporalio::Workflow.logger.info(...)` |
+| `Mutex` / `synchronize` | explicit `Temporalio::Workflow::Mutex` |
 
 ## Testing Replay Compatibility
 

--- a/references/ruby/determinism.md
+++ b/references/ruby/determinism.md
@@ -20,7 +20,7 @@ Configuration is via the `illegal_workflow_calls` parameter on `Temporalio::Work
 Temporalio::Worker.default_illegal_workflow_calls
 ```
 
-## Forbidden Operations
+## Forbidden Operations in Workflows
 
 The following are forbidden inside workflow code by default:
 
@@ -33,7 +33,7 @@ The following are forbidden inside workflow code by default:
 - Network calls (`Net::HTTP`, `Socket`, etc.)
 - `Mutex` / `synchronize`
 
-## Safe Builtin Alternatives
+## Safe Builtin Alternatives to Common Non Deterministic Things
 
 | Forbidden | Safe Alternative |
 |-----------|------------------|

--- a/references/ruby/error-handling.md
+++ b/references/ruby/error-handling.md
@@ -34,7 +34,7 @@ raise Temporalio::Error::ApplicationError.new(
 
 ```ruby
 begin
-  await workflow.execute_activity(MyActivity, 'arg', start_to_close_timeout: 10)
+  Temporalio::Workflow.execute_activity(MyActivity, 'arg', start_to_close_timeout: 10)
 rescue Temporalio::Error::ActivityError => e
   Temporalio::Workflow.logger.error("Activity failed: #{e.message}")
   # handle or re-raise
@@ -56,7 +56,7 @@ Only set retry policies when you have a domain-specific reason. Prefer the defau
 ## Timeout Configuration
 
 ```ruby
-workflow.execute_activity(
+Temporalio::Workflow.execute_activity(
   MyActivity,
   'arg',
   start_to_close_timeout: 30,

--- a/references/ruby/error-handling.md
+++ b/references/ruby/error-handling.md
@@ -1,0 +1,102 @@
+# Ruby SDK Error Handling
+
+## Overview
+
+Application errors use `Temporalio::Error::ApplicationError`. Retry behavior is configured via `Temporalio::RetryPolicy`.
+
+## Application Errors
+
+```ruby
+raise Temporalio::Error::ApplicationError.new('message', type: 'ErrorType')
+```
+
+In activities, any Ruby exception is automatically converted to an `ApplicationError`.
+
+## Non-Retryable Errors
+
+```ruby
+raise Temporalio::Error::ApplicationError.new(
+  'message',
+  non_retryable: true
+)
+```
+
+Override the retry interval with `next_retry_delay:`:
+
+```ruby
+raise Temporalio::Error::ApplicationError.new(
+  'message',
+  next_retry_delay: 30
+)
+```
+
+## Handling Activity Errors in Workflows
+
+```ruby
+begin
+  await workflow.execute_activity(MyActivity, 'arg', start_to_close_timeout: 10)
+rescue Temporalio::Error::ActivityError => e
+  Temporalio::Workflow.logger.error("Activity failed: #{e.message}")
+  # handle or re-raise
+end
+```
+
+## Retry Configuration
+
+```ruby
+retry_policy: Temporalio::RetryPolicy.new(
+  max_interval: 60,
+  max_attempts: 5,
+  non_retryable_error_types: ['ValidationError']
+)
+```
+
+Only set retry policies when you have a domain-specific reason. Prefer the defaults otherwise.
+
+## Timeout Configuration
+
+```ruby
+workflow.execute_activity(
+  MyActivity,
+  'arg',
+  start_to_close_timeout: 30,
+  schedule_to_close_timeout: 300,
+  heartbeat_timeout: 10
+)
+```
+
+All timeout values are in seconds (numeric).
+
+## Workflow Failure
+
+Only `Temporalio::Error::ApplicationError` causes a workflow failure. Other exceptions cause a workflow task failure, which Temporal retries automatically.
+
+Control which exception types cause workflow failure:
+
+```ruby
+class MyWorkflow
+  # Class method approach
+  def self.workflow_failure_exception_type
+    MyCustomError
+  end
+end
+```
+
+Or configure on the worker:
+
+```ruby
+Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-queue',
+  workflows: [MyWorkflow],
+  workflow_failure_exception_types: [MyCustomError]
+)
+```
+
+## Best Practices
+
+- Use specific error types (`type:` parameter) for differentiation.
+- Mark permanent failures as `non_retryable: true`.
+- Set retry policies only when defaults are insufficient.
+- Log errors before re-raising.
+- Design activities for idempotency so retries are safe.

--- a/references/ruby/error-handling.md
+++ b/references/ruby/error-handling.md
@@ -30,7 +30,7 @@ raise Temporalio::Error::ApplicationError.new(
 )
 ```
 
-## Handling Activity Errors in Workflows
+## Handling Activity Errors
 
 ```ruby
 begin
@@ -41,7 +41,7 @@ rescue Temporalio::Error::ActivityError => e
 end
 ```
 
-## Retry Configuration
+## Retry Policy Configuration
 
 ```ruby
 retry_policy: Temporalio::RetryPolicy.new(

--- a/references/ruby/error-handling.md
+++ b/references/ruby/error-handling.md
@@ -78,27 +78,21 @@ All timeout values are in seconds (numeric).
 
 Only `Temporalio::Error::ApplicationError` causes a workflow failure. Other exceptions cause a workflow task failure, which Temporal retries automatically.
 
-Control which exception types cause workflow failure:
-
 ```ruby
-class MyWorkflow
-  # Class method approach
-  def self.workflow_failure_exception_type
-    MyCustomError
+class MyWorkflow < Temporalio::Workflow::Definition
+  def execute
+    if some_condition
+      raise Temporalio::Error::ApplicationError.new(
+        'Cannot process order',
+        type: 'BusinessError'
+      )
+    end
+    'success'
   end
 end
 ```
 
-Or configure on the worker:
-
-```ruby
-Temporalio::Worker.new(
-  client: client,
-  task_queue: 'my-queue',
-  workflows: [MyWorkflow],
-  workflow_failure_exception_types: [MyCustomError]
-)
-```
+**Note:** Do not use `non_retryable:` with `ApplicationError` inside a workflow (as opposed to an activity).
 
 ## Best Practices
 

--- a/references/ruby/error-handling.md
+++ b/references/ruby/error-handling.md
@@ -36,8 +36,15 @@ raise Temporalio::Error::ApplicationError.new(
 begin
   Temporalio::Workflow.execute_activity(MyActivity, 'arg', start_to_close_timeout: 10)
 rescue Temporalio::Error::ActivityError => e
+  # Let cancellation propagate so the workflow is canceled, not failed.
+  # Temporalio::Error.canceled? is true for a CanceledError, or an
+  # ActivityError/ChildWorkflowError whose cause is a CanceledError.
+  raise if Temporalio::Error.canceled?(e)
+
   Temporalio::Workflow.logger.error("Activity failed: #{e.message}")
-  # handle or re-raise
+  # Deliberately fail the workflow. Only raising an ApplicationError fails a
+  # workflow; other exceptions only fail/retry the workflow task.
+  raise Temporalio::Error::ApplicationError.new('Workflow failed due to activity error')
 end
 ```
 

--- a/references/ruby/gotchas.md
+++ b/references/ruby/gotchas.md
@@ -1,0 +1,245 @@
+# Ruby Gotchas
+
+Ruby-specific mistakes and anti-patterns. See also [Common Gotchas](references/core/gotchas.md) for language-agnostic concepts.
+
+## File Organization
+
+Unlike Python, Ruby doesn't reload workflow files (no sandbox). Still best practice to separate workflows and activities for clarity and maintainability.
+
+```ruby
+# BAD - Everything in one file
+# app.rb
+class MyWorkflow < Temporalio::Workflow::Definition
+  def execute(name)
+    Temporalio::Workflow.execute_activity(
+      MyActivity,
+      name,
+      start_to_close_timeout: 30
+    )
+  end
+end
+
+class MyActivity < Temporalio::Activity::Definition
+  def execute(name)
+    # Heavy I/O, external calls, etc.
+  end
+end
+```
+
+```ruby
+# GOOD - Separate files
+# workflows/my_workflow.rb
+require 'temporalio/workflow/definition'
+
+class MyWorkflow < Temporalio::Workflow::Definition
+  def execute(name)
+    Temporalio::Workflow.execute_activity(
+      MyActivity,
+      name,
+      start_to_close_timeout: 30
+    )
+  end
+end
+
+# activities/my_activity.rb
+require 'temporalio/activity/definition'
+
+class MyActivity < Temporalio::Activity::Definition
+  def execute(name)
+    # Heavy I/O, external calls, etc.
+  end
+end
+
+# worker.rb
+require_relative 'workflows/my_workflow'
+require_relative 'activities/my_activity'
+```
+
+## Wrong Retry Classification
+
+Transient network errors should be retried. Authentication errors should not be. See `references/ruby/error-handling.md` to understand how to classify errors with `non_retryable: true` and `non_retryable_error_types`.
+
+## Cancellation
+
+### Not Handling Workflow Cancellation
+
+```ruby
+# BAD - Cleanup doesn't run on cancellation
+class BadWorkflow < Temporalio::Workflow::Definition
+  def execute
+    Temporalio::Workflow.execute_activity(AcquireResource, start_to_close_timeout: 300)
+    Temporalio::Workflow.execute_activity(DoWork, start_to_close_timeout: 300)
+    Temporalio::Workflow.execute_activity(ReleaseResource, start_to_close_timeout: 300)  # Never runs if cancelled!
+  end
+end
+```
+
+```ruby
+# GOOD - Use ensure with detached cancellation scope for cleanup
+class GoodWorkflow < Temporalio::Workflow::Definition
+  def execute
+    Temporalio::Workflow.execute_activity(AcquireResource, start_to_close_timeout: 300)
+    Temporalio::Workflow.execute_activity(DoWork, start_to_close_timeout: 300)
+  ensure
+    # Detach so cleanup runs even when cancelled
+    Temporalio::Workflow::CancellationScope.new(detached: true) do
+      Temporalio::Workflow.execute_activity(ReleaseResource, start_to_close_timeout: 300)
+    end
+  end
+end
+```
+
+### Activity Cancellation Requires Heartbeating
+
+Activities must **opt in** to receive cancellation. This requires heartbeating -- cancellation is delivered via the heartbeat response.
+
+```ruby
+# BAD - Activity ignores cancellation
+class LongActivity < Temporalio::Activity::Definition
+  def execute
+    do_expensive_work  # Runs to completion even if cancelled
+  end
+end
+```
+
+```ruby
+# GOOD - Heartbeat and handle cancellation
+class LongActivity < Temporalio::Activity::Definition
+  def execute
+    items.each do |item|
+      Temporalio::Activity::Context.current.heartbeat
+      process(item)
+    end
+  rescue Temporalio::Error::CancelledError
+    cleanup
+    raise
+  end
+end
+```
+
+## Heartbeating
+
+### Forgetting to Heartbeat Long Activities
+
+```ruby
+# BAD - No heartbeat, can't detect stuck activities
+class ProcessLargeFile < Temporalio::Activity::Definition
+  def execute(path)
+    File.readlines(path).each_slice(1000) do |chunk|
+      process(chunk)  # Takes hours, no heartbeat
+    end
+  end
+end
+```
+
+```ruby
+# GOOD - Regular heartbeats with progress
+class ProcessLargeFile < Temporalio::Activity::Definition
+  def execute(path)
+    File.readlines(path).each_slice(1000).with_index do |chunk, i|
+      Temporalio::Activity::Context.current.heartbeat("Processing chunk #{i}")
+      process(chunk)
+    end
+  end
+end
+```
+
+### Heartbeat Timeout Too Short
+
+```ruby
+# BAD - Heartbeat timeout shorter than processing time between heartbeats
+Temporalio::Workflow.execute_activity(
+  ProcessChunk,
+  start_to_close_timeout: 1800,
+  heartbeat_timeout: 10  # Too short!
+)
+
+# GOOD - Heartbeat timeout allows for processing variance
+Temporalio::Workflow.execute_activity(
+  ProcessChunk,
+  start_to_close_timeout: 1800,
+  heartbeat_timeout: 120
+)
+```
+
+Set heartbeat timeout as high as acceptable for your use case -- each heartbeat counts as an action.
+
+## Testing
+
+### Not Testing Failures
+
+Make sure workflows work as expected under failure paths, not just happy paths. See `references/ruby/testing.md` for more info.
+
+### Not Testing Replay
+
+Replay tests help you detect hidden sources of non-determinism in your workflow code and should be considered in addition to standard testing. See `references/ruby/testing.md` for more info.
+
+## Timers and Sleep
+
+### Using Kernel.sleep
+
+```ruby
+# BAD - Kernel.sleep raises NondeterminismError
+class BadWorkflow < Temporalio::Workflow::Definition
+  def execute
+    sleep(60)          # NondeterminismError!
+    Kernel.sleep(60)   # NondeterminismError!
+  end
+end
+```
+
+```ruby
+# GOOD - Use Temporalio::Workflow.sleep for durable timers
+class GoodWorkflow < Temporalio::Workflow::Definition
+  def execute
+    Temporalio::Workflow.sleep(60)  # Deterministic, durable timer
+  end
+end
+```
+
+**Why this matters:** `Kernel.sleep` uses the system clock, which differs between original execution and replay. `Temporalio::Workflow.sleep` creates a durable timer in the event history, ensuring consistent behavior during replay.
+
+## Illegal Call Tracing Gotchas
+
+### Third-Party Gems Triggering NondeterminismError
+
+The Ruby SDK uses `TracePoint`-based illegal call tracing on the workflow fiber. Any gem that internally uses `Thread`, `IO`, `Socket`, `Net::HTTP`, or other forbidden operations will trigger `NondeterminismError` -- even if the call is deep in the gem's internals.
+
+```ruby
+# BAD - Logging gem that uses Thread internally
+class MyWorkflow < Temporalio::Workflow::Definition
+  def execute
+    SomeFancyLogger.info("Starting workflow")  # NondeterminismError if gem uses Thread.new!
+  end
+end
+```
+
+### Fix: Disable Illegal Call Tracing for Specific Code
+
+```ruby
+# Wrap non-deterministic but safe code
+Temporalio::Workflow::Unsafe.illegal_call_tracing_disabled do
+  # Code here won't trigger NondeterminismError
+  SomeFancyLogger.info("Starting workflow")
+end
+```
+
+For code that performs IO that you know is safe and want to allow:
+
+```ruby
+# Disable the durable scheduler for IO operations
+Temporalio::Workflow::Unsafe.durable_scheduler_disabled do
+  # IO operations allowed here
+end
+```
+
+### Side Effects and Replay Safety
+
+Always check replaying status before performing side effects in workflows:
+
+```ruby
+unless Temporalio::Workflow::Unsafe.replaying?
+  # Only runs during original execution, not replay
+  Temporalio::Workflow.logger.info("Processing started")
+end
+```

--- a/references/ruby/gotchas.md
+++ b/references/ruby/gotchas.md
@@ -29,7 +29,7 @@ end
 ```ruby
 # GOOD - Separate files
 # workflows/my_workflow.rb
-require 'temporalio/workflow/definition'
+require 'temporalio/workflow'
 
 class MyWorkflow < Temporalio::Workflow::Definition
   def execute(name)
@@ -42,7 +42,7 @@ class MyWorkflow < Temporalio::Workflow::Definition
 end
 
 # activities/my_activity.rb
-require 'temporalio/activity/definition'
+require 'temporalio/activity'
 
 class MyActivity < Temporalio::Activity::Definition
   def execute(name)
@@ -75,16 +75,20 @@ end
 ```
 
 ```ruby
-# GOOD - Use ensure with detached cancellation scope for cleanup
+# GOOD - Use ensure with detached cancellation for cleanup
 class GoodWorkflow < Temporalio::Workflow::Definition
   def execute
     Temporalio::Workflow.execute_activity(AcquireResource, start_to_close_timeout: 300)
     Temporalio::Workflow.execute_activity(DoWork, start_to_close_timeout: 300)
   ensure
-    # Detach so cleanup runs even when cancelled
-    Temporalio::Workflow::CancellationScope.new(detached: true) do
-      Temporalio::Workflow.execute_activity(ReleaseResource, start_to_close_timeout: 300)
-    end
+    # Create a detached cancellation (not tied to workflow cancellation)
+    # so cleanup activity runs even after workflow is cancelled
+    detached_cancel, _cancel_proc = Temporalio::Cancellation.new
+    Temporalio::Workflow.execute_activity(
+      ReleaseResource,
+      start_to_close_timeout: 300,
+      cancellation: detached_cancel
+    )
   end
 end
 ```

--- a/references/ruby/gotchas.md
+++ b/references/ruby/gotchas.md
@@ -129,7 +129,7 @@ end
 # BAD - No heartbeat, can't detect stuck activities
 class ProcessLargeFile < Temporalio::Activity::Definition
   def execute(path)
-    File.readlines(path).each_slice(1000) do |chunk|
+    File.foreach(path).each_slice(1000) do |chunk|
       process(chunk)  # Takes hours, no heartbeat
     end
   end
@@ -140,7 +140,7 @@ end
 # GOOD - Regular heartbeats with progress
 class ProcessLargeFile < Temporalio::Activity::Definition
   def execute(path)
-    File.readlines(path).each_slice(1000).with_index do |chunk, i|
+    File.foreach(path).each_slice(1000).with_index do |chunk, i|
       Temporalio::Activity::Context.current.heartbeat("Processing chunk #{i}")
       process(chunk)
     end

--- a/references/ruby/gotchas.md
+++ b/references/ruby/gotchas.md
@@ -59,67 +59,6 @@ require_relative 'activities/my_activity'
 
 Transient network errors should be retried. Authentication errors should not be. See `references/ruby/error-handling.md` to understand how to classify errors with `non_retryable: true` and `non_retryable_error_types`.
 
-## Cancellation
-
-### Not Handling Workflow Cancellation
-
-```ruby
-# BAD - Cleanup doesn't run on cancellation
-class BadWorkflow < Temporalio::Workflow::Definition
-  def execute
-    Temporalio::Workflow.execute_activity(AcquireResource, start_to_close_timeout: 300)
-    Temporalio::Workflow.execute_activity(DoWork, start_to_close_timeout: 300)
-    Temporalio::Workflow.execute_activity(ReleaseResource, start_to_close_timeout: 300)  # Never runs if cancelled!
-  end
-end
-```
-
-```ruby
-# GOOD - Use ensure with detached cancellation for cleanup
-class GoodWorkflow < Temporalio::Workflow::Definition
-  def execute
-    Temporalio::Workflow.execute_activity(AcquireResource, start_to_close_timeout: 300)
-    Temporalio::Workflow.execute_activity(DoWork, start_to_close_timeout: 300)
-  ensure
-    # Create a detached cancellation (not tied to workflow cancellation)
-    # so cleanup activity runs even after workflow is cancelled
-    detached_cancel, _cancel_proc = Temporalio::Cancellation.new
-    Temporalio::Workflow.execute_activity(
-      ReleaseResource,
-      start_to_close_timeout: 300,
-      cancellation: detached_cancel
-    )
-  end
-end
-```
-
-### Activity Cancellation Requires Heartbeating
-
-Activities must **opt in** to receive cancellation. This requires heartbeating -- cancellation is delivered via the heartbeat response.
-
-```ruby
-# BAD - Activity ignores cancellation
-class LongActivity < Temporalio::Activity::Definition
-  def execute
-    do_expensive_work  # Runs to completion even if cancelled
-  end
-end
-```
-
-```ruby
-# GOOD - Heartbeat and handle cancellation
-class LongActivity < Temporalio::Activity::Definition
-  def execute
-    items.each do |item|
-      Temporalio::Activity::Context.current.heartbeat
-      process(item)
-    end
-  rescue Temporalio::Error::CancelledError
-    cleanup
-    raise
-  end
-end
-```
 
 ## Heartbeating
 
@@ -167,6 +106,71 @@ Temporalio::Workflow.execute_activity(
 ```
 
 Set heartbeat timeout as high as acceptable for your use case -- each heartbeat counts as an action.
+
+## Cancellation
+
+### Not Handling Workflow Cancellation
+
+```ruby
+# BAD - Cleanup doesn't run on cancellation
+class BadWorkflow < Temporalio::Workflow::Definition
+  def execute
+    Temporalio::Workflow.execute_activity(AcquireResource, start_to_close_timeout: 300)
+    Temporalio::Workflow.execute_activity(DoWork, start_to_close_timeout: 300)
+    Temporalio::Workflow.execute_activity(ReleaseResource, start_to_close_timeout: 300)  # Never runs if cancelled!
+  end
+end
+```
+
+```ruby
+# GOOD - Use ensure with detached cancellation for cleanup
+class GoodWorkflow < Temporalio::Workflow::Definition
+  def execute
+    Temporalio::Workflow.execute_activity(AcquireResource, start_to_close_timeout: 300)
+    Temporalio::Workflow.execute_activity(DoWork, start_to_close_timeout: 300)
+  ensure
+    # Create a detached cancellation (not tied to workflow cancellation)
+    # so cleanup activity runs even after workflow is cancelled
+    detached_cancel, _cancel_proc = Temporalio::Cancellation.new
+    Temporalio::Workflow.execute_activity(
+      ReleaseResource,
+      start_to_close_timeout: 300,
+      cancellation: detached_cancel
+    )
+  end
+end
+```
+
+### Not Handling Activity Cancellation
+
+Activities must **opt in** to receive cancellation. This requires:
+
+1. **Heartbeating** -- cancellation is delivered via the heartbeat response
+2. **Catching the cancellation exception** -- `Temporalio::Error::CancelledError` is raised when a heartbeat detects cancellation
+
+```ruby
+# BAD - Activity ignores cancellation
+class LongActivity < Temporalio::Activity::Definition
+  def execute
+    do_expensive_work  # Runs to completion even if cancelled
+  end
+end
+```
+
+```ruby
+# GOOD - Heartbeat and handle cancellation
+class LongActivity < Temporalio::Activity::Definition
+  def execute
+    items.each do |item|
+      Temporalio::Activity::Context.current.heartbeat
+      process(item)
+    end
+  rescue Temporalio::Error::CancelledError
+    cleanup
+    raise
+  end
+end
+```
 
 ## Testing
 

--- a/references/ruby/observability.md
+++ b/references/ruby/observability.md
@@ -1,0 +1,62 @@
+# Ruby SDK Observability
+
+## Overview
+
+Temporal Ruby SDK provides logging, metrics, tracing, and visibility for monitoring workflows and activities.
+
+## Logging
+
+Workflow (replay-safe):
+
+```ruby
+Temporalio::Workflow.logger.info("Processing order")
+Temporalio::Workflow.logger.warn("Retrying with fallback")
+Temporalio::Workflow.logger.error("Order failed: #{reason}")
+```
+
+Activity:
+
+```ruby
+Temporalio::Activity::Context.current.logger.info("Sending email")
+Temporalio::Activity::Context.current.logger.warn("Slow response: #{elapsed}s")
+```
+
+Do not use `puts` or `print` in workflows. They are not replay-safe and produce duplicate output on replay.
+
+## Metrics
+
+Configure telemetry via `Temporalio::Runtime`:
+
+```ruby
+prometheus_options = Temporalio::Runtime::PrometheusMetricsOptions.new(
+  bind_address: '0.0.0.0:9000'
+)
+
+metrics_options = Temporalio::Runtime::MetricsOptions.new(
+  prometheus: prometheus_options
+)
+
+telemetry_options = Temporalio::Runtime::TelemetryOptions.new(
+  metrics: metrics_options
+)
+
+runtime = Temporalio::Runtime.new(telemetry: telemetry_options)
+Temporalio::Runtime.default = runtime
+```
+
+Set the default runtime **before** creating any clients or workers.
+
+Key metrics:
+
+- `temporal_workflow_completed` - workflow completions
+- `temporal_workflow_failed` - workflow failures
+- `temporal_activity_execution_latency` - activity duration
+- `temporal_sticky_cache_hit` - workflow cache hits
+- `temporal_workflow_task_execution_latency` - workflow task duration
+
+## Best Practices
+
+- Use `Temporalio::Workflow.logger` in workflows, `Temporalio::Activity::Context.current.logger` in activities.
+- Configure Prometheus metrics for production deployments.
+- Use Search Attributes for workflow visibility and filtering.
+- Never use `puts` or `print` in workflow code.

--- a/references/ruby/observability.md
+++ b/references/ruby/observability.md
@@ -38,6 +38,8 @@ client = Temporalio::Client.connect(
 
 ## Metrics
 
+### Enabling SDK Metrics
+
 Configure telemetry via `Temporalio::Runtime`:
 
 ```ruby
@@ -59,7 +61,7 @@ Temporalio::Runtime.default = runtime
 
 Set the default runtime **before** creating any clients or workers.
 
-Key metrics:
+### Key SDK Metrics
 
 - `temporal_workflow_completed` - workflow completions
 - `temporal_workflow_failed` - workflow failures

--- a/references/ruby/observability.md
+++ b/references/ruby/observability.md
@@ -6,7 +6,7 @@ Temporal Ruby SDK provides logging, metrics, tracing, and visibility for monitor
 
 ## Logging
 
-Workflow (replay-safe):
+### Workflow Logging (Replay-Safe)
 
 ```ruby
 Temporalio::Workflow.logger.info("Processing order")
@@ -14,7 +14,7 @@ Temporalio::Workflow.logger.warn("Retrying with fallback")
 Temporalio::Workflow.logger.error("Order failed: #{reason}")
 ```
 
-Activity:
+### Activity Logging
 
 ```ruby
 Temporalio::Activity::Context.current.logger.info("Sending email")
@@ -53,6 +53,10 @@ Key metrics:
 - `temporal_activity_execution_latency` - activity duration
 - `temporal_sticky_cache_hit` - workflow cache hits
 - `temporal_workflow_task_execution_latency` - workflow task duration
+
+## Search Attributes (Visibility)
+
+See the Search Attributes section of `references/ruby/data-handling.md`
 
 ## Best Practices
 

--- a/references/ruby/observability.md
+++ b/references/ruby/observability.md
@@ -23,6 +23,19 @@ Temporalio::Activity::Context.current.logger.warn("Slow response: #{elapsed}s")
 
 Do not use `puts` or `print` in workflows. They are not replay-safe and produce duplicate output on replay.
 
+### Customizing Logger Configuration
+
+```ruby
+require 'logger'
+
+# The logger set on the client is used by Temporalio::Workflow.logger and
+# Temporalio::Activity::Context.current.logger. Defaults to stdout at WARN.
+client = Temporalio::Client.connect(
+  'localhost:7233', 'my-namespace',
+  logger: Logger.new($stdout, level: Logger::INFO)
+)
+```
+
 ## Metrics
 
 Configure telemetry via `Temporalio::Runtime`:

--- a/references/ruby/patterns.md
+++ b/references/ruby/patterns.md
@@ -19,8 +19,7 @@ class OrderWorkflow < Temporalio::Workflow::Definition
     @items << item
   end
 
-  workflow_run
-  def run
+  def execute
     Temporalio::Workflow.wait_condition { @approved }
     "Processed #{@items.length} items"
   end
@@ -56,21 +55,10 @@ class StatusWorkflow < Temporalio::Workflow::Definition
     @progress = 0
   end
 
-  workflow_query
-  def get_status
-    @status
-  end
-
-  workflow_query
-  def get_progress
-    @progress
-  end
-
   # Shorthand for simple attribute readers
   workflow_query_attr_reader :status, :progress
 
-  workflow_run
-  def run
+  def execute
     @status = 'running'
     100.times do |i|
       @progress = i
@@ -125,8 +113,7 @@ end
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run(orders)
+  def execute(orders)
     results = []
     orders.each do |order|
       result = Temporalio::Workflow.execute_child_workflow(
@@ -158,8 +145,7 @@ Temporalio::Workflow.execute_child_workflow(
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run(target_workflow_id)
+  def execute(target_workflow_id)
     handle = Temporalio::Workflow.external_workflow_handle(target_workflow_id)
 
     # Signal the external workflow
@@ -175,8 +161,7 @@ end
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run(items)
+  def execute(items)
     futures = items.map do |item|
       Temporalio::Workflow::Future.new do
         Temporalio::Workflow.execute_activity(
@@ -196,8 +181,7 @@ end
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run(state)
+  def execute(state)
     loop do
       state = process_batch(state)
 
@@ -218,8 +202,7 @@ end
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run(order)
+  def execute(order)
     compensations = []
 
     begin
@@ -279,8 +262,7 @@ Ruby uses `Temporalio::Cancellation` tokens instead of asyncio cancellation.
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run
+  def execute
     # The workflow's cancellation token
     workflow_cancel = Temporalio::Workflow.cancellation
 
@@ -309,8 +291,7 @@ end
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run
+  def execute
     @approved = false
 
     # Wait for approval with 24-hour timeout
@@ -332,8 +313,7 @@ When async handlers are necessary, use `wait_condition { all_handlers_finished }
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run
+  def execute
     # ... main workflow logic ...
 
     # Before exiting, wait for all handlers to finish
@@ -387,8 +367,7 @@ end
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run
+  def execute
     Temporalio::Workflow.sleep(3600)
 
     'Timer fired'
@@ -402,8 +381,7 @@ end
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition
-  workflow_run
-  def run
+  def execute
     result = Temporalio::Workflow.execute_local_activity(
       QuickLookup, 'key',
       start_to_close_timeout: 5

--- a/references/ruby/patterns.md
+++ b/references/ruby/patterns.md
@@ -149,7 +149,7 @@ class MyWorkflow < Temporalio::Workflow::Definition
     handle = Temporalio::Workflow.external_workflow_handle(target_workflow_id)
 
     # Signal the external workflow
-    handle.signal(TargetWorkflow, :data_ready, data_payload)
+    handle.signal(TargetWorkflow.data_ready, data_payload)
 
     # Or cancel it
     handle.cancel
@@ -317,7 +317,7 @@ class MyWorkflow < Temporalio::Workflow::Definition
     # ... main workflow logic ...
 
     # Before exiting, wait for all handlers to finish
-    Temporalio::Workflow.wait_condition { Temporalio::Workflow.all_handlers_finished }
+    Temporalio::Workflow.wait_condition { Temporalio::Workflow.all_handlers_finished? }
     'done'
   end
 end

--- a/references/ruby/patterns.md
+++ b/references/ruby/patterns.md
@@ -1,0 +1,418 @@
+# Ruby SDK Patterns
+
+## Signals
+
+```ruby
+class OrderWorkflow < Temporalio::Workflow::Definition
+  def initialize
+    @approved = false
+    @items = []
+  end
+
+  workflow_signal
+  def approve
+    @approved = true
+  end
+
+  workflow_signal
+  def add_item(item)
+    @items << item
+  end
+
+  workflow_run
+  def run
+    Temporalio::Workflow.wait_condition { @approved }
+    "Processed #{@items.length} items"
+  end
+end
+```
+
+### Dynamic Signal Handlers
+
+For handling signals with names not known at compile time. Use cases for this pattern are rare — most workflows should use statically defined signal handlers.
+
+```ruby
+class DynamicSignalWorkflow < Temporalio::Workflow::Definition
+  def initialize
+    @signals = {}
+  end
+
+  workflow_signal dynamic: true, raw_args: true
+  def dynamic_signal(signal_name, *args)
+    @signals[signal_name] ||= []
+    @signals[signal_name] << Temporalio::Workflow.payload_converter.from_payload(args.first)
+  end
+end
+```
+
+## Queries
+
+**Important:** Queries must NOT modify workflow state or have side effects.
+
+```ruby
+class StatusWorkflow < Temporalio::Workflow::Definition
+  def initialize
+    @status = 'pending'
+    @progress = 0
+  end
+
+  workflow_query
+  def get_status
+    @status
+  end
+
+  workflow_query
+  def get_progress
+    @progress
+  end
+
+  # Shorthand for simple attribute readers
+  workflow_query_attr_reader :status, :progress
+
+  workflow_run
+  def run
+    @status = 'running'
+    100.times do |i|
+      @progress = i
+      Temporalio::Workflow.execute_activity(
+        ProcessItem, i,
+        start_to_close_timeout: 60
+      )
+    end
+    @status = 'completed'
+    'done'
+  end
+end
+```
+
+### Dynamic Query Handlers
+
+For handling queries with names not known at compile time. Use cases for this pattern are rare — most workflows should use statically defined query handlers.
+
+```ruby
+workflow_query dynamic: true, raw_args: true
+def dynamic_query(query_name, *args)
+  if query_name == 'get_field'
+    field_name = Temporalio::Workflow.payload_converter.from_payload(args.first)
+    instance_variable_get(:"@#{field_name}")
+  end
+end
+```
+
+## Updates
+
+```ruby
+class OrderWorkflow < Temporalio::Workflow::Definition
+  def initialize
+    @items = []
+  end
+
+  workflow_update
+  def add_item(item)
+    @items << item
+    @items.length # Returns new count to caller
+  end
+
+  workflow_update_validator(:add_item)
+  def validate_add_item(item)
+    raise 'Item cannot be empty' if item.nil? || item.empty?
+    raise 'Order is full' if @items.length >= 100
+  end
+end
+```
+
+## Child Workflows
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run(orders)
+    results = []
+    orders.each do |order|
+      result = Temporalio::Workflow.execute_child_workflow(
+        ProcessOrderWorkflow, order,
+        id: "order-#{order.id}",
+        parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON
+      )
+      results << result
+    end
+    results
+  end
+end
+```
+
+### Child Workflow Options
+
+```ruby
+Temporalio::Workflow.execute_child_workflow(
+  ChildWorkflow, arg,
+  id: 'child-1',
+  parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON,
+  cancellation_type: Temporalio::Workflow::ChildWorkflowCancellationType::WAIT_CANCELLATION_COMPLETED,
+  execution_timeout: 3600,
+  run_timeout: 1800
+)
+```
+
+## Handles to External Workflows
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run(target_workflow_id)
+    handle = Temporalio::Workflow.external_workflow_handle(target_workflow_id)
+
+    # Signal the external workflow
+    handle.signal(TargetWorkflow, :data_ready, data_payload)
+
+    # Or cancel it
+    handle.cancel
+  end
+end
+```
+
+## Parallel Execution
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run(items)
+    futures = items.map do |item|
+      Temporalio::Workflow::Future.new do
+        Temporalio::Workflow.execute_activity(
+          ProcessItem, item,
+          start_to_close_timeout: 300
+        )
+      end
+    end
+    Temporalio::Workflow::Future.all_of(*futures).wait
+    results = futures.map(&:result)
+    results
+  end
+end
+```
+
+## Continue-as-New
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run(state)
+    loop do
+      state = process_batch(state)
+
+      return 'done' if state.complete?
+
+      # Continue with fresh history before hitting limits
+      if Temporalio::Workflow.continue_as_new_suggested
+        raise Temporalio::Workflow::ContinueAsNewError.new(state)
+      end
+    end
+  end
+end
+```
+
+## Saga Pattern (Compensations)
+
+**Important:** Compensation activities should be idempotent - they may be retried (as with ALL activities).
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run(order)
+    compensations = []
+
+    begin
+      # Save compensation before running the activity, because:
+      # 1. reserve_inventory starts running
+      # 2. it successfully reserves inventory
+      # 3. but then fails for some other reason (timeout, reporting metrics, etc.)
+      # 4. the activity failed, but the effect (reserved inventory) already happened
+      # So the compensation must handle both reserved and unreserved states.
+      compensations << lambda {
+        Temporalio::Workflow.execute_activity(
+          ReleaseInventoryIfReserved, order,
+          start_to_close_timeout: 300
+        )
+      }
+      Temporalio::Workflow.execute_activity(
+        ReserveInventory, order,
+        start_to_close_timeout: 300
+      )
+
+      compensations << lambda {
+        Temporalio::Workflow.execute_activity(
+          RefundPaymentIfCharged, order,
+          start_to_close_timeout: 300
+        )
+      }
+      Temporalio::Workflow.execute_activity(
+        ChargePayment, order,
+        start_to_close_timeout: 300
+      )
+
+      Temporalio::Workflow.execute_activity(
+        ShipOrder, order,
+        start_to_close_timeout: 300
+      )
+
+      'Order completed'
+
+    rescue => e
+      Temporalio::Workflow.logger.error("Order failed: #{e}, running compensations")
+      compensations.reverse.each do |compensate|
+        begin
+          compensate.call
+        rescue => comp_err
+          Temporalio::Workflow.logger.error("Compensation failed: #{comp_err}")
+        end
+      end
+      raise
+    end
+  end
+end
+```
+
+## Cancellation (Token-based)
+
+Ruby uses `Temporalio::Cancellation` tokens instead of asyncio cancellation.
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run
+    # The workflow's cancellation token
+    workflow_cancel = Temporalio::Workflow.cancellation
+
+    begin
+      Temporalio::Workflow.execute_activity(
+        LongRunningActivity,
+        start_to_close_timeout: 3600,
+        cancellation: workflow_cancel
+      )
+      'completed'
+    ensure
+      # Create a detached cancellation for cleanup
+      # (not tied to workflow cancellation)
+      cancel, _cancel_proc = Temporalio::Cancellation.new
+      Temporalio::Workflow.execute_activity(
+        CleanupActivity,
+        start_to_close_timeout: 300,
+        cancellation: cancel
+      )
+    end
+  end
+end
+```
+
+## Wait Condition with Timeout
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run
+    @approved = false
+
+    # Wait for approval with 24-hour timeout
+    # Returns false on timeout (no exception raised)
+    if Temporalio::Workflow.wait_condition(timeout: 86400) { @approved }
+      'approved'
+    else
+      'auto-rejected due to timeout'
+    end
+  end
+end
+```
+
+## Waiting for All Handlers to Finish
+
+Signal and update handlers should generally be non-async (avoid running activities from them). Otherwise, the workflow may complete before handlers finish their execution. However, making handlers non-async sometimes requires workarounds that add complexity.
+
+When async handlers are necessary, use `wait_condition { all_handlers_finished }` at the end of your workflow (or before continue-as-new) to prevent completion until all pending handlers complete.
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run
+    # ... main workflow logic ...
+
+    # Before exiting, wait for all handlers to finish
+    Temporalio::Workflow.wait_condition { Temporalio::Workflow.all_handlers_finished }
+    'done'
+  end
+end
+```
+
+## Activity Heartbeat Details
+
+### WHY:
+- **Support activity cancellation** - Cancellations are delivered via heartbeat; activities that don't heartbeat won't know they've been cancelled
+- **Resume progress after worker failure** - Heartbeat details persist across retries
+
+### WHEN:
+- **Cancellable activities** - Any activity that should respond to cancellation
+- **Long-running activities** - Track progress for resumability
+- **Checkpointing** - Save progress periodically
+
+```ruby
+class ProcessLargeFile < Temporalio::Activity::Definition
+  def execute(file_path)
+    context = Temporalio::Activity::Context.current
+
+    # Get heartbeat details from previous attempt (if any)
+    heartbeat_details = context.info.heartbeat_details
+    start_line = heartbeat_details&.first || 0
+
+    begin
+      File.foreach(file_path).with_index do |line, i|
+        next if i < start_line
+
+        process_line(line)
+
+        # Heartbeat with progress
+        # If cancelled, heartbeat raises Temporalio::Error::CanceledError
+        context.heartbeat(i + 1)
+      end
+
+      'completed'
+    rescue Temporalio::Error::CanceledError
+      cleanup
+      raise
+    end
+  end
+end
+```
+
+## Timers
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run
+    Temporalio::Workflow.sleep(3600)
+
+    'Timer fired'
+  end
+end
+```
+
+## Local Activities
+
+**Purpose**: Reduce latency for short, lightweight operations by skipping the task queue. ONLY use these when necessary for performance. Do NOT use these by default, as they are not durable and distributed.
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  workflow_run
+  def run
+    result = Temporalio::Workflow.execute_local_activity(
+      QuickLookup, 'key',
+      start_to_close_timeout: 5
+    )
+    result
+  end
+end
+```
+
+## Using ActiveModel
+
+See `references/ruby/data-handling.md`.

--- a/references/ruby/patterns.md
+++ b/references/ruby/patterns.md
@@ -258,7 +258,7 @@ end
 
 ## Cancellation (Token-based)
 
-Ruby uses `Temporalio::Cancellation` tokens instead of asyncio cancellation.
+Ruby uses `Temporalio::Cancellation` tokens.
 
 ```ruby
 class MyWorkflow < Temporalio::Workflow::Definition

--- a/references/ruby/patterns.md
+++ b/references/ruby/patterns.md
@@ -109,6 +109,8 @@ class OrderWorkflow < Temporalio::Workflow::Definition
 end
 ```
 
+**Important:** Validators must NOT mutate workflow state or do anything blocking (no activities, sleeps, or other commands). They are read-only, similar to query handlers. Raise an exception to reject the update; return `nil` to accept.
+
 ## Child Workflows
 
 ```ruby

--- a/references/ruby/patterns.md
+++ b/references/ruby/patterns.md
@@ -214,10 +214,11 @@ class MyWorkflow < Temporalio::Workflow::Definition
       # 3. but then fails for some other reason (timeout, reporting metrics, etc.)
       # 4. the activity failed, but the effect (reserved inventory) already happened
       # So the compensation must handle both reserved and unreserved states.
-      compensations << lambda {
+      compensations << lambda { |cancellation|
         Temporalio::Workflow.execute_activity(
           ReleaseInventoryIfReserved, order,
-          start_to_close_timeout: 300
+          start_to_close_timeout: 300,
+          cancellation: cancellation
         )
       }
       Temporalio::Workflow.execute_activity(
@@ -225,10 +226,11 @@ class MyWorkflow < Temporalio::Workflow::Definition
         start_to_close_timeout: 300
       )
 
-      compensations << lambda {
+      compensations << lambda { |cancellation|
         Temporalio::Workflow.execute_activity(
           RefundPaymentIfCharged, order,
-          start_to_close_timeout: 300
+          start_to_close_timeout: 300,
+          cancellation: cancellation
         )
       }
       Temporalio::Workflow.execute_activity(
@@ -245,9 +247,12 @@ class MyWorkflow < Temporalio::Workflow::Definition
 
     rescue => e
       Temporalio::Workflow.logger.error("Order failed: #{e}, running compensations")
+      # Use a detached cancellation so compensations still run even if the workflow
+      # was canceled (the workflow's own cancellation is already canceled by then).
+      detached_cancel, = Temporalio::Cancellation.new
       compensations.reverse.each do |compensate|
         begin
-          compensate.call
+          compensate.call(detached_cancel)
         rescue => comp_err
           Temporalio::Workflow.logger.error("Compensation failed: #{comp_err}")
         end

--- a/references/ruby/ruby.md
+++ b/references/ruby/ruby.md
@@ -43,7 +43,7 @@ require_relative 'say_hello_workflow'
 
 # Create client connected to server at the given address
 # This is the default port for `temporal server start-dev`
-client = Temporalio::Client.connect('localhost:7233')
+client = Temporalio::Client.connect('localhost:7233', 'default')
 
 # Create and run the worker
 worker = Temporalio::Worker.new(
@@ -66,7 +66,7 @@ require 'securerandom'
 require_relative 'say_hello_workflow'
 
 # Create client connected to server at the given address
-client = Temporalio::Client.connect('localhost:7233')
+client = Temporalio::Client.connect('localhost:7233', 'default')
 
 # Execute a workflow
 result = client.execute_workflow(

--- a/references/ruby/ruby.md
+++ b/references/ruby/ruby.md
@@ -10,7 +10,7 @@ The Temporal Ruby SDK (`temporalio` gem) provides a class-based approach to buil
 
 **say_hello_activity.rb** - Activity definition:
 ```ruby
-require 'temporalio/activity/definition'
+require 'temporalio/activity'
 
 class SayHelloActivity < Temporalio::Activity::Definition
   def execute(name)
@@ -21,7 +21,7 @@ end
 
 **say_hello_workflow.rb** - Workflow definition:
 ```ruby
-require 'temporalio/workflow/definition'
+require 'temporalio/workflow'
 
 class SayHelloWorkflow < Temporalio::Workflow::Definition
   def execute(name)

--- a/references/ruby/ruby.md
+++ b/references/ruby/ruby.md
@@ -1,0 +1,146 @@
+# Temporal Ruby SDK Reference
+
+## Overview
+
+The Temporal Ruby SDK (`temporalio` gem) provides a class-based approach to building durable workflows. Ruby 3.3+ required. Workflows run using a Durable Fiber Scheduler for determinism protection, with Illegal Call Tracing via `TracePoint` to detect non-deterministic operations.
+
+## Quick Demo of Temporal
+
+**Add Dependency on Temporal:** Add `temporalio` to your Gemfile or install directly with `gem install temporalio`.
+
+**say_hello_activity.rb** - Activity definition:
+```ruby
+require 'temporalio/activity/definition'
+
+class SayHelloActivity < Temporalio::Activity::Definition
+  def execute(name)
+    "Hello, #{name}!"
+  end
+end
+```
+
+**say_hello_workflow.rb** - Workflow definition:
+```ruby
+require 'temporalio/workflow/definition'
+
+class SayHelloWorkflow < Temporalio::Workflow::Definition
+  def execute(name)
+    Temporalio::Workflow.execute_activity(
+      SayHelloActivity,
+      name,
+      schedule_to_close_timeout: 30
+    )
+  end
+end
+```
+
+**worker.rb** - Worker setup (imports activity and workflow, runs indefinitely and processes tasks):
+```ruby
+require 'temporalio/client'
+require 'temporalio/worker'
+require_relative 'say_hello_activity'
+require_relative 'say_hello_workflow'
+
+# Create client connected to server at the given address
+# This is the default port for `temporal server start-dev`
+client = Temporalio::Client.connect('localhost:7233')
+
+# Create and run the worker
+worker = Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-task-queue',
+  workflows: [SayHelloWorkflow],
+  activities: [SayHelloActivity]
+)
+worker.run
+```
+
+**Start the dev server:** Start `temporal server start-dev` in the background.
+
+**Start the worker:** Start `ruby worker.rb` in the background.
+
+**execute_workflow.rb** - Start a workflow execution:
+```ruby
+require 'temporalio/client'
+require 'securerandom'
+require_relative 'say_hello_workflow'
+
+# Create client connected to server at the given address
+client = Temporalio::Client.connect('localhost:7233')
+
+# Execute a workflow
+result = client.execute_workflow(
+  SayHelloWorkflow,
+  'my name',
+  id: SecureRandom.uuid,
+  task_queue: 'my-task-queue'
+)
+
+puts "Result: #{result}"
+```
+
+**Run the workflow:** Run `ruby execute_workflow.rb`. Should output: `Result: Hello, my name!`.
+
+## Key Concepts
+
+### Workflow Definition
+- Subclass `Temporalio::Workflow::Definition`
+- Define `def execute(args)` as the entry point
+- Use `Temporalio::Workflow.execute_activity` to call activities
+- Use signals, queries, and updates via class-level DSL methods
+
+### Activity Definition
+- Subclass `Temporalio::Activity::Definition`
+- Define `def execute(args)` as the entry point
+- Activities contain all non-deterministic and side-effectful code
+- Can access `Temporalio::Activity::Context.current` for heartbeating
+
+### Worker Setup
+- Connect client with `Temporalio::Client.connect`
+- Create worker with `Temporalio::Worker.new(client:, task_queue:, workflows:, activities:)`
+- Run with `worker.run`
+
+### Determinism
+
+**Workflow code must be deterministic!** The Ruby SDK uses a Durable Fiber Scheduler and Illegal Call Tracing (via Ruby's `TracePoint`) to detect non-deterministic operations at runtime. All sources of non-determinism should either use Temporal-provided alternatives or be defined in Activities. Read `references/core/determinism.md` and `references/ruby/determinism.md` to understand more.
+
+## File Organization Best Practice
+
+**Keep Workflow definitions in separate files from Activity definitions.** Unlike Python, Ruby does not have a sandbox reloading concern, but separating workflows and activities is still good practice for clarity and maintainability. Use `require_relative` to import between files.
+
+```
+my_temporal_app/
+├── workflows/
+│   └── say_hello_workflow.rb   # Only Workflow classes
+├── activities/
+│   └── say_hello_activity.rb   # Only Activity classes
+├── worker.rb                   # Worker setup, requires both
+└── execute_workflow.rb          # Client code to start workflows
+```
+
+## Common Pitfalls
+
+1. **Using `sleep` instead of `Temporalio::Workflow.sleep`** - Standard `sleep` is non-deterministic and will be flagged by Illegal Call Tracing; use the Temporal-provided version
+2. **Using `Time.now` instead of `Temporalio::Workflow.now`** - Same issue; `Time.now` is non-deterministic in workflow context
+3. **Third-party gems triggering illegal calls** - Gems that perform I/O, use threads, or call system time will be caught by `TracePoint` tracing; move that logic to activities
+4. **Using `puts`/`Logger` in workflows** - Use `Temporalio::Workflow.logger` instead for replay-safe logging
+5. **Not heartbeating long activities** - Long-running activities need `Temporalio::Activity::Context.current.heartbeat`
+6. **Mixing Workflows and Activities in same file** - Bad structure; keep them separated for clarity
+
+## Writing Tests
+
+See `references/ruby/testing.md` for info on writing tests.
+
+## Additional Resources
+
+### Reference Files
+- **`references/ruby/patterns.md`** - Signals, queries, child workflows, saga pattern, etc.
+- **`references/ruby/determinism.md`** - Durable Fiber Scheduler behavior, safe alternatives, history replay
+- **`references/ruby/determinism-protection.md`** - Illegal Call Tracing via TracePoint, forbidden operations, runtime detection
+- **`references/ruby/versioning.md`** - Patching API, workflow type versioning, Worker Versioning
+- **`references/ruby/testing.md`** - Test environments, time-skipping, activity mocking
+- **`references/ruby/error-handling.md`** - ApplicationError, retry policies, non-retryable errors, idempotency
+- **`references/ruby/data-handling.md`** - Data converters, payload encryption
+- **`references/ruby/observability.md`** - Logging, metrics, tracing, Search Attributes
+- **`references/ruby/gotchas.md`** - Ruby-specific mistakes and anti-patterns
+- **`references/ruby/advanced-features.md`** - Schedules, worker tuning, and more

--- a/references/ruby/ruby.md
+++ b/references/ruby/ruby.md
@@ -87,7 +87,7 @@ puts "Result: #{result}"
 - Subclass `Temporalio::Workflow::Definition`
 - Define `def execute(args)` as the entry point
 - Use `Temporalio::Workflow.execute_activity` to call activities
-- Use signals, queries, and updates via class-level DSL methods
+- Define signals, queries, and updates via class-level DSL methods
 
 ### Activity Definition
 - Subclass `Temporalio::Activity::Definition`

--- a/references/ruby/testing.md
+++ b/references/ruby/testing.md
@@ -1,0 +1,234 @@
+# Ruby SDK Testing
+
+## Overview
+
+The Temporal Ruby SDK provides testing utilities compatible with any Ruby test framework (minitest is commonly used). The two main testing classes are `Temporalio::Testing::WorkflowEnvironment` for end-to-end workflow testing and `Temporalio::Testing::ActivityEnvironment` for isolated activity testing.
+
+## Workflow Test Environment
+
+The core pattern:
+1. Start a test `WorkflowEnvironment` with `start_local`
+2. Create a Worker in that environment with your Workflows and Activities registered
+3. Execute the Workflow using the environment's client
+4. Assert on the result
+
+```ruby
+require 'minitest/autorun'
+require 'securerandom'
+require 'temporalio/testing/workflow_environment'
+require 'temporalio/worker'
+
+require_relative '../workflows/my_workflow'
+require_relative '../activities/my_activity'
+
+class MyWorkflowTest < Minitest::Test
+  def test_workflow_returns_expected_result
+    Temporalio::Testing::WorkflowEnvironment.start_local do |env|
+      task_queue = SecureRandom.uuid
+
+      worker = Temporalio::Worker.new(
+        client: env.client,
+        task_queue: task_queue,
+        workflows: [MyWorkflow],
+        activities: [MyActivity]
+      )
+
+      worker.run do
+        result = env.client.execute_workflow(
+          MyWorkflow,
+          'input-arg',
+          id: SecureRandom.uuid,
+          task_queue: task_queue
+        )
+
+        assert_equal 'expected output', result
+      end
+    end
+  end
+end
+```
+
+For workflows with long durations (timers, sleeps), use `start_time_skipping` instead of `start_local`:
+
+```ruby
+Temporalio::Testing::WorkflowEnvironment.start_time_skipping do |env|
+  # Timers are automatically skipped
+end
+```
+
+## Mocking Activities
+
+Create fake activity classes with the same activity name as the real ones. Pass them to the Worker instead of the real activities:
+
+```ruby
+class FakeComposeGreetingActivity < Temporalio::Activity::Definition
+  activity_name 'ComposeGreetingActivity'
+
+  def execute(input)
+    'mocked greeting'
+  end
+end
+
+class MyWorkflowMockTest < Minitest::Test
+  def test_workflow_with_mocked_activity
+    Temporalio::Testing::WorkflowEnvironment.start_local do |env|
+      task_queue = SecureRandom.uuid
+
+      worker = Temporalio::Worker.new(
+        client: env.client,
+        task_queue: task_queue,
+        workflows: [MyWorkflow],
+        activities: [FakeComposeGreetingActivity]
+      )
+
+      worker.run do
+        result = env.client.execute_workflow(
+          MyWorkflow,
+          'test-input',
+          id: SecureRandom.uuid,
+          task_queue: task_queue
+        )
+
+        assert_equal 'mocked greeting', result
+      end
+    end
+  end
+end
+```
+
+## Testing Signals and Queries
+
+Use `start_workflow` to get a handle, then interact via signal/query methods:
+
+```ruby
+class SignalQueryTest < Minitest::Test
+  def test_signal_and_query
+    Temporalio::Testing::WorkflowEnvironment.start_local do |env|
+      task_queue = SecureRandom.uuid
+
+      worker = Temporalio::Worker.new(
+        client: env.client,
+        task_queue: task_queue,
+        workflows: [MyWorkflow],
+        activities: [MyActivity]
+      )
+
+      worker.run do
+        handle = env.client.start_workflow(
+          MyWorkflow,
+          id: SecureRandom.uuid,
+          task_queue: task_queue
+        )
+
+        # Send a signal
+        handle.signal(MyWorkflow.my_signal, 'signal-data')
+
+        # Query workflow state
+        status = handle.query(MyWorkflow.get_status)
+        assert_equal 'expected-status', status
+
+        # Wait for completion
+        result = handle.result
+        assert_equal 'done', result
+      end
+    end
+  end
+end
+```
+
+## Testing Failure Cases
+
+Test workflows that encounter errors using activities that raise exceptions:
+
+```ruby
+class FailingActivity < Temporalio::Activity::Definition
+  activity_name 'MyActivity'
+
+  def execute(input)
+    raise Temporalio::Error::ApplicationError.new('Simulated failure', non_retryable: true)
+  end
+end
+
+class FailureTest < Minitest::Test
+  def test_workflow_handles_activity_failure
+    Temporalio::Testing::WorkflowEnvironment.start_local do |env|
+      task_queue = SecureRandom.uuid
+
+      worker = Temporalio::Worker.new(
+        client: env.client,
+        task_queue: task_queue,
+        workflows: [MyWorkflow],
+        activities: [FailingActivity]
+      )
+
+      worker.run do
+        assert_raises(Temporalio::Error::WorkflowFailureError) do
+          env.client.execute_workflow(
+            MyWorkflow,
+            'input',
+            id: SecureRandom.uuid,
+            task_queue: task_queue
+          )
+        end
+      end
+    end
+  end
+end
+```
+
+## Replay Testing
+
+Use `WorkflowReplayer` to verify that workflow code changes remain compatible with existing histories:
+
+```ruby
+require 'temporalio/worker/workflow_replayer'
+require 'temporalio/workflow_history'
+
+class ReplayTest < Minitest::Test
+  def test_replay_from_json
+    json = File.read('test/fixtures/my_workflow_history.json')
+    replayer = Temporalio::Worker::WorkflowReplayer.new(workflows: [MyWorkflow])
+
+    # Replay a single workflow history
+    replayer.replay_workflow(
+      Temporalio::WorkflowHistory.from_history_json(json)
+    )
+  end
+
+  def test_replay_bulk
+    histories = Dir['test/fixtures/histories/*.json'].map do |path|
+      Temporalio::WorkflowHistory.from_history_json(File.read(path))
+    end
+
+    replayer = Temporalio::Worker::WorkflowReplayer.new(workflows: [MyWorkflow])
+
+    # Replay multiple histories - raises on nondeterminism
+    replayer.replay_workflows(histories)
+  end
+end
+```
+
+## Activity Testing
+
+Use `ActivityEnvironment` to test activities in isolation without a full Temporal server:
+
+```ruby
+require 'temporalio/testing/activity_environment'
+
+class ActivityTest < Minitest::Test
+  def test_activity_returns_greeting
+    env = Temporalio::Testing::ActivityEnvironment.new
+    result = env.run(MyActivity, 'World')
+    assert_equal 'Hello, World!', result
+  end
+end
+```
+
+## Best Practices
+
+1. **Use `start_local` for most tests** - provides a real Temporal environment without external dependencies
+2. **Use `start_time_skipping` for timer tests** - automatically skips timers rather than waiting
+3. **Mock external dependencies** - create fake activity classes with `activity_name` matching the real activity
+4. **Test replay compatibility** - add replay tests when changing workflow code to catch nondeterminism errors early
+5. **Use unique IDs per test** - use `SecureRandom.uuid` for workflow IDs and task queue names to avoid conflicts
+6. **Test signals and queries explicitly** - use `start_workflow` to get a handle rather than `execute_workflow`

--- a/references/ruby/testing.md
+++ b/references/ruby/testing.md
@@ -176,7 +176,7 @@ class FailureTest < Minitest::Test
 end
 ```
 
-## Replay Testing
+## Workflow Replay Testing
 
 Use `WorkflowReplayer` to verify that workflow code changes remain compatible with existing histories:
 

--- a/references/ruby/versioning.md
+++ b/references/ruby/versioning.md
@@ -1,0 +1,293 @@
+# Ruby SDK Versioning
+
+For conceptual overview, see `references/core/versioning.md`.
+
+## Patching API
+
+### The patched() Method
+
+`Temporalio::Workflow.patched('my-patch')` returns `true`/`false` to branch between new and old code paths:
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  def execute
+    if Temporalio::Workflow.patched('my-patch')
+      # New code path
+      Temporalio::Workflow.execute_activity(
+        PostPatchActivity,
+        start_to_close_timeout: 100
+      )
+    else
+      # Old code path (for replay of existing workflows)
+      Temporalio::Workflow.execute_activity(
+        PrePatchActivity,
+        start_to_close_timeout: 100
+      )
+    end
+  end
+end
+```
+
+**How it works:**
+- For new executions: `patched()` returns `true` and records a marker in the Workflow history
+- For replay with the marker: `patched()` returns `true` (history includes this patch)
+- For replay without the marker: `patched()` returns `false` (history predates this patch)
+
+### Three-Step Patching Process
+
+**Step 1: Patch in New Code**
+
+Add the patch with both old and new code paths:
+
+```ruby
+class OrderWorkflow < Temporalio::Workflow::Definition
+  def execute(order)
+    if Temporalio::Workflow.patched('add-fraud-check')
+      # New: Run fraud check before payment
+      Temporalio::Workflow.execute_activity(
+        CheckFraudActivity,
+        order,
+        start_to_close_timeout: 120
+      )
+    end
+
+    # Original payment logic runs for both paths
+    Temporalio::Workflow.execute_activity(
+      ProcessPaymentActivity,
+      order,
+      start_to_close_timeout: 300
+    )
+  end
+end
+```
+
+**Step 2: Deprecate the Patch**
+
+Once all pre-patch Workflow Executions have completed, remove the old code and use `deprecate_patch()`:
+
+```ruby
+class OrderWorkflow < Temporalio::Workflow::Definition
+  def execute(order)
+    Temporalio::Workflow.deprecate_patch('add-fraud-check')
+
+    # Only new code remains
+    Temporalio::Workflow.execute_activity(
+      CheckFraudActivity,
+      order,
+      start_to_close_timeout: 120
+    )
+
+    Temporalio::Workflow.execute_activity(
+      ProcessPaymentActivity,
+      order,
+      start_to_close_timeout: 300
+    )
+  end
+end
+```
+
+**Step 3: Remove the Patch**
+
+After all workflows with the deprecated patch marker have completed, remove the `deprecate_patch()` call entirely:
+
+```ruby
+class OrderWorkflow < Temporalio::Workflow::Definition
+  def execute(order)
+    Temporalio::Workflow.execute_activity(
+      CheckFraudActivity,
+      order,
+      start_to_close_timeout: 120
+    )
+
+    Temporalio::Workflow.execute_activity(
+      ProcessPaymentActivity,
+      order,
+      start_to_close_timeout: 300
+    )
+  end
+end
+```
+
+### Query Filters for Finding Workflows by Version
+
+```bash
+# Find running workflows with a specific patch
+temporal workflow list --query \
+  'WorkflowType = "OrderWorkflow" AND ExecutionStatus = "Running" AND TemporalChangeVersion = "add-fraud-check"'
+
+# Find running workflows without any patch (pre-patch versions)
+temporal workflow list --query \
+  'WorkflowType = "OrderWorkflow" AND ExecutionStatus = "Running" AND TemporalChangeVersion IS NULL'
+```
+
+## Workflow Type Versioning
+
+For incompatible changes, create a new Workflow Type by duplicating the class:
+
+```ruby
+class MyWorkflow < Temporalio::Workflow::Definition
+  def execute
+    # Original implementation
+    Temporalio::Workflow.execute_activity(
+      OriginalActivity,
+      start_to_close_timeout: 100
+    )
+  end
+end
+
+class MyWorkflowV2 < Temporalio::Workflow::Definition
+  def execute
+    # New implementation with incompatible changes
+    Temporalio::Workflow.execute_activity(
+      NewActivity,
+      start_to_close_timeout: 100
+    )
+  end
+end
+```
+
+Register both with the Worker:
+
+```ruby
+worker = Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-task-queue',
+  workflows: [MyWorkflow, MyWorkflowV2],
+  activities: [OriginalActivity, NewActivity]
+)
+```
+
+Update client code to start new workflows with the new type:
+
+```ruby
+# Old workflows continue on MyWorkflow
+# New workflows use MyWorkflowV2
+handle = client.start_workflow(
+  MyWorkflowV2,
+  input,
+  id: SecureRandom.uuid,
+  task_queue: 'my-task-queue'
+)
+```
+
+Check for open executions before removing the old type:
+
+```bash
+temporal workflow list --query 'WorkflowType = "MyWorkflow" AND ExecutionStatus = "Running"'
+```
+
+## Worker Versioning
+
+Worker Versioning manages versions at the deployment level, allowing multiple Worker versions to run simultaneously. Requires Ruby SDK v0.5.0+.
+
+### Key Concepts
+
+**Worker Deployment**: A logical service grouping similar Workers together (e.g., "order-processor"). All versions of your code live under this umbrella.
+
+**Worker Deployment Version**: A specific snapshot of your code identified by a deployment name and Build ID (e.g., "order-processor:v1.0" or "order-processor:abc123").
+
+### Configuring Workers for Versioning
+
+```ruby
+worker = Temporalio::Worker.new(
+  client: client,
+  task_queue: 'my-task-queue',
+  workflows: [MyWorkflow],
+  activities: [MyActivity],
+  deployment_config: Temporalio::Worker::DeploymentConfig.new(
+    version: Temporalio::Worker::DeploymentVersion.new(
+      deployment_name: 'my-service',
+      build_id: 'v1.0.0' # or git commit hash
+    ),
+    use_worker_versioning: true
+  )
+)
+```
+
+### PINNED vs AUTO_UPGRADE Behaviors
+
+**PINNED Behavior**
+
+Workflows stay locked to their original Worker version. Set on the workflow definition:
+
+```ruby
+class StableWorkflow < Temporalio::Workflow::Definition
+  workflow_versioning_behavior :pinned
+
+  def execute
+    Temporalio::Workflow.execute_activity(
+      ProcessOrderActivity,
+      start_to_close_timeout: 300
+    )
+  end
+end
+```
+
+**When to use PINNED:**
+- Short-running workflows (minutes to hours)
+- Consistency is critical (e.g., financial transactions)
+- You want to eliminate version compatibility complexity
+- Building new applications and want simplest development experience
+
+**AUTO_UPGRADE Behavior**
+
+Workflows can move to newer versions:
+
+```ruby
+class LongRunningWorkflow < Temporalio::Workflow::Definition
+  workflow_versioning_behavior :auto_upgrade
+
+  def execute
+    # This workflow may be picked up by a newer Worker version
+    Temporalio::Workflow.execute_activity(
+      ProcessActivity,
+      start_to_close_timeout: 300
+    )
+  end
+end
+```
+
+**When to use AUTO_UPGRADE:**
+- Long-running workflows (weeks or months)
+- Workflows need to benefit from bug fixes during execution
+- Migrating from traditional rolling deployments
+- You are already using patching APIs for version transitions
+
+**Important:** AUTO_UPGRADE workflows still need patching to handle version transitions safely since they can move between Worker versions.
+
+### Deployment Strategies
+
+**Blue-Green Deployments**
+
+Maintain two environments and switch traffic between them:
+1. Deploy new code to idle environment
+2. Run tests and validation
+3. Switch traffic to new environment
+4. Keep old environment for instant rollback
+
+**Rainbow Deployments**
+
+Multiple versions run simultaneously:
+- New workflows use latest version
+- Existing workflows complete on their original version
+- Add new versions alongside existing ones
+- Gradually sunset old versions as workflows complete
+
+This works well with Kubernetes where you manage multiple ReplicaSets running different Worker versions.
+
+### Querying Workflows by Worker Version
+
+```bash
+# Find workflows on a specific Worker version
+temporal workflow list --query \
+  'TemporalWorkerDeploymentVersion = "my-service:v1.0.0" AND ExecutionStatus = "Running"'
+```
+
+## Best Practices
+
+1. **Check for open executions** before removing old code paths
+2. **Use descriptive patch IDs** that explain the change (e.g., "add-fraud-check" not "patch-1")
+3. **Deploy patches incrementally**: patch, deprecate, remove
+4. **Use PINNED for short workflows** to simplify version management
+5. **Use AUTO_UPGRADE with patching** for long-running workflows that need updates
+6. **Generate Build IDs from code** (git hash) to ensure changes produce new versions

--- a/references/ruby/versioning.md
+++ b/references/ruby/versioning.md
@@ -259,6 +259,25 @@ end
 
 **Important:** AUTO_UPGRADE workflows still need patching to handle version transitions safely since they can move between Worker versions.
 
+### Worker Configuration with Default Behavior
+
+```ruby
+worker = Temporalio::Worker.new(
+  client: client,
+  task_queue: 'orders-task-queue',
+  workflows: [OrderWorkflow],
+  activities: [ProcessOrderActivity],
+  deployment_options: Temporalio::Worker::DeploymentOptions.new(
+    version: Temporalio::WorkerDeploymentVersion.new(
+      deployment_name: 'order-service',
+      build_id: ENV.fetch('BUILD_ID')
+    ),
+    use_worker_versioning: true,
+    default_versioning_behavior: Temporalio::VersioningBehavior::PINNED
+  )
+)
+```
+
 ### Deployment Strategies
 
 **Blue-Green Deployments**

--- a/references/ruby/versioning.md
+++ b/references/ruby/versioning.md
@@ -198,8 +198,8 @@ worker = Temporalio::Worker.new(
   task_queue: 'my-task-queue',
   workflows: [MyWorkflow],
   activities: [MyActivity],
-  deployment_config: Temporalio::Worker::DeploymentConfig.new(
-    version: Temporalio::Worker::DeploymentVersion.new(
+  deployment_options: Temporalio::Worker::DeploymentOptions.new(
+    version: Temporalio::WorkerDeploymentVersion.new(
       deployment_name: 'my-service',
       build_id: 'v1.0.0' # or git commit hash
     ),

--- a/references/ruby/versioning.md
+++ b/references/ruby/versioning.md
@@ -35,6 +35,8 @@ end
 
 ### Three-Step Patching Process
 
+**Warning:** Failing to follow this process correctly will result in non-determinism errors for in-flight workflows.
+
 **Step 1: Patch in New Code**
 
 Add the patch with both old and new code paths:
@@ -291,3 +293,4 @@ temporal workflow list --query \
 4. **Use PINNED for short workflows** to simplify version management
 5. **Use AUTO_UPGRADE with patching** for long-running workflows that need updates
 6. **Generate Build IDs from code** (git hash) to ensure changes produce new versions
+7. **Avoid rolling deployments** for high-availability services with long-running workflows

--- a/references/ruby/versioning.md
+++ b/references/ruby/versioning.md
@@ -33,6 +33,8 @@ end
 - For replay with the marker: `patched()` returns `true` (history includes this patch)
 - For replay without the marker: `patched()` returns `false` (history predates this patch)
 
+**Note:** The `patched()` return value is memoized per patch ID. This means you cannot reliably use `patched()` in loops—it will return the same value every iteration. Workaround: append a sequence number to the patch ID for each iteration (e.g., `"my-change-#{i}"`).
+
 ### Three-Step Patching Process
 
 **Warning:** Failing to follow this process correctly will result in non-determinism errors for in-flight workflows.


### PR DESCRIPTION
## Summary
- Add 11 Ruby reference files (~2100 lines) covering all major Temporal SDK features: workflows, activities, signals/queries/updates, child workflows, versioning, testing, error handling, data conversion, observability, determinism protection, and advanced features
- Update SKILL.md to include Ruby in description, overview, and getting started guide
- Add Ruby entry to core/determinism.md SDK Protection Mechanisms section

## Details
The Ruby SDK (`temporalio` gem, GA) uses a fundamentally different determinism approach from Python (sandbox) and TypeScript (V8 isolate):
- **Illegal Call Tracing** via Ruby's `TracePoint` to detect forbidden method calls at runtime
- **Durable Fiber Scheduler** to make fiber operations deterministic

Ruby-specific sections added that don't exist in Python/TypeScript:
- Cancellation (Token-based) — uses `Temporalio::Cancellation` objects
- ActiveModel Integration — Ruby equivalent of Pydantic
- Converter Hints — `workflow_arg_hint`/`workflow_result_hint` for type guidance
- Illegal Call Tracing Gotchas — third-party gems triggering NondeterminismError
- Activity Concurrency and Executors — ThreadPool configuration
- Rails Integration — ActiveRecord, Zeitwerk, forking considerations

## Test plan
- [ ] Verify Ruby reference files are loaded correctly by the skill
- [ ] Test with a sample Ruby Temporal project to validate code examples
- [ ] Review alignment with Python/TypeScript content structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)