### PR TITLE
Fix saga compensations to run under cancellation protection

### DIFF
--- a/references/python/patterns.md
+++ b/references/python/patterns.md
@@ -243,11 +243,14 @@ class MyWorkflow:
 
         except Exception as e:
             workflow.logger.error(f"Order failed: {e}, running compensations")
-            for compensate in reversed(compensations):
-                try:
-                    await compensate()
-                except Exception as comp_err:
-                    workflow.logger.error(f"Compensation failed: {comp_err}")
+            # asyncio.shield ensures compensations run even if the workflow is cancelled.
+            async def run_compensations():
+                for compensate in reversed(compensations):
+                    try:
+                        await compensate()
+                    except Exception as comp_err:
+                        workflow.logger.error(f"Compensation failed: {comp_err}")
+            await asyncio.shield(asyncio.ensure_future(run_compensations()))
             raise
 ```
 

--- a/references/typescript/patterns.md
+++ b/references/typescript/patterns.md
@@ -224,7 +224,7 @@ export async function longRunningWorkflow(state: State): Promise<string> {
 **Important:** Compensation activities should be idempotent.
 
 ```typescript
-import { log } from '@temporalio/workflow';
+import { CancellationScope, log } from '@temporalio/workflow';
 
 export async function sagaWorkflow(order: Order): Promise<string> {
   const compensations: Array<() => Promise<void>> = [];
@@ -233,22 +233,25 @@ export async function sagaWorkflow(order: Order): Promise<string> {
     // IMPORTANT: Save compensation BEFORE calling the activity
     // If activity fails after completing but before returning,
     // compensation must still be registered
-    await reserveInventory(order);
     compensations.push(() => releaseInventory(order));
+    await reserveInventory(order);
 
-    await chargePayment(order);
     compensations.push(() => refundPayment(order));
+    await chargePayment(order);
 
     await shipOrder(order);
     return 'Order completed';
   } catch (err) {
-    for (const compensate of compensations.reverse()) {
-      try {
-        await compensate();
-      } catch (compErr) {
-        log.warn('Compensation failed', { error: compErr });
+    // nonCancellable ensures compensations run even if the workflow is cancelled
+    await CancellationScope.nonCancellable(async () => {
+      for (const compensate of compensations.reverse()) {
+        try {
+          await compensate();
+        } catch (compErr) {
+          log.warn('Compensation failed', { error: compErr });
+        }
       }
-    }
+    });
     throw err;
   }
 }


### PR DESCRIPTION
Based on discussion here: https://github.com/temporalio/skill-temporal-developer/pull/38#discussion_r2948628999, this PR also fixes saga pattern for Python and TypeScript to run under cancellation protection.

Additionally, TypeScript is fixed to save compensations *before* activities!