### PR TITLE
Fix Python reference bugs

### DIFF
--- a/references/python/ai-patterns.md
+++ b/references/python/ai-patterns.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document provides Python-specific implementation details for integrating LLMs with Temporal. For conceptual patterns, see `references/core/ai-integration.md`.
+This document provides Python-specific implementation details for integrating LLMs with Temporal. For conceptual patterns, see `references/core/ai-patterns.md`.
 
 ## Pydantic Data Converter Setup
 

--- a/references/python/determinism.md
+++ b/references/python/determinism.md
@@ -23,7 +23,7 @@ Temporal provides durable execution through **History Replay**. When a Worker ne
 |-----------|------------------|
 | `datetime.now()` | `workflow.now()` |
 | `datetime.utcnow()` | `workflow.now()` |
-| `random.random()` | `rng = workflow.new_random() ; rng.randint(1, 100)` |
+| `random.random()` | `rng = workflow.random() ; rng.randint(1, 100)` |
 | `uuid.uuid4()` | `workflow.uuid4()` |
 | `time.time()` | `workflow.now().timestamp()` |
 

--- a/references/python/testing.md
+++ b/references/python/testing.md
@@ -136,7 +136,7 @@ async def test_replay():
 
     # From JSON file
     await replayer.replay_workflow(
-        WorkflowHistory.from_json(workflow_id=str(uuid.uuid4()), history_json)
+        WorkflowHistory.from_json(str(uuid.uuid4()), history_json)
     )
 ```
 


### PR DESCRIPTION
## Summary

Fixes three bugs in the Python SDK reference documents:

- **`references/python/determinism.md`**: Changed `workflow.new_random()` to `workflow.random()` in the safe alternatives table. The correct API is `workflow.random()`, which is also used correctly in the best practices section of the same file.

- **`references/python/testing.md`**: Removed the `workflow_id=` keyword argument in `WorkflowHistory.from_json(workflow_id=str(uuid.uuid4()), history_json)`. This is a Python syntax error — a keyword argument cannot precede a positional argument. The first parameter is positional (`workflow_id`), so it should be passed without the keyword when followed by a positional `history_json`.

- **`references/python/ai-patterns.md`**: Fixed cross-reference from `references/core/ai-integration.md` to `references/core/ai-patterns.md`, which is the file that actually exists.