### PR TITLE
Fix typos and broken references across skill docs

### DIFF
--- a/references/core/error-reference.md
+++ b/references/core/error-reference.md
@@ -1,6 +1,6 @@
 # Common Error Types Reference
 
-| Error Type | Error identifier (if any) | Where to Find | What Happened | Recovery | Link to additional info (if any)
+| Error Type | Error identifier (if any) | Where to Find | What Happened | Recovery | Link to additional info (if any) |
 |------------|---------------|---------------|---------------|----------|----------|
 | **Non-determinism** | TMPRL1100 | `WorkflowTaskFailed` in history | Replay doesn't match history | Analyze error first. **If accidental**: fix code to match history → restart worker. **If intentional v2 change**: terminate → start fresh workflow. | https://github.com/temporalio/rules/blob/main/rules/TMPRL1100.md |
 | **Deadlock** | TMPRL1101 | `WorkflowTaskFailed` in history, worker logs | Workflow blocked too long (deadlock detected) | Remove blocking operations from workflow code (no I/O, no sleep, no threading locks). Use Temporal primitives instead. | https://github.com/temporalio/rules/blob/main/rules/TMPRL1101.md |

--- a/references/core/patterns.md
+++ b/references/core/patterns.md
@@ -253,9 +253,9 @@ To ensure that polling_activity is restarted in a timely manner, we make sure th
 
 **Implementation**:
 
-Define an Activty which fails (raises an exception) exactly when polling is not completed.
+Define an Activity which fails (raises an exception) exactly when polling is not completed.
 
-The polling loop is accomplised via activity retries, by setting the following Retry options:
+The polling loop is accomplished via activity retries, by setting the following Retry options:
 - backoff_coefficient: to 1
 - initial_interval: to the polling interval (e.g. 60 seconds)
 

--- a/references/core/troubleshooting.md
+++ b/references/core/troubleshooting.md
@@ -192,7 +192,7 @@ Timeout error?
 ├─▶ Which timeout?
 │   │
 │   ├─▶ Workflow timeout
-│   │   └─▶ Increase timeout or optimize workflow. Better yet, consider removing the workflow timeout, as it is generally discourged unless *necessary* for your use case.
+│   │   └─▶ Increase timeout or optimize workflow. Better yet, consider removing the workflow timeout, as it is generally discouraged unless *necessary* for your use case.
 │   │
 │   ├─▶ ScheduleToCloseTimeout
 │   │   └─▶ Activity taking too long overall (including retries)

--- a/references/go/determinism-protection.md
+++ b/references/go/determinism-protection.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Go SDK has no runtime sandbox. Determinism is enforced by **developer convention** and **optional static analysis**. Unlike the Python and TypeScript SDKs, the Go SDK will not intercept or replace non-deterministic calls at runtime. The Go SDK does perform a limited runtime command-ordering check, but catching non-deterministic code before deployment requires the `workflowcheck` tool and testing, in particular replay tests (see `references/go/testing`).
+The Go SDK has no runtime sandbox. Determinism is enforced by **developer convention** and **optional static analysis**. Unlike the Python and TypeScript SDKs, the Go SDK will not intercept or replace non-deterministic calls at runtime. The Go SDK does perform a limited runtime command-ordering check, but catching non-deterministic code before deployment requires the `workflowcheck` tool and testing, in particular replay tests (see `references/go/testing.md`).
 
 ## workflowcheck Static Analysis
 

--- a/references/go/go.md
+++ b/references/go/go.md
@@ -239,4 +239,4 @@ See `references/go/testing.md` for info on writing tests.
 - **`references/go/advanced-features.md`** - Schedules, worker tuning, and more
 - **`references/go/data-handling.md`** - Data converters, payload codecs, encryption
 - **`references/go/versioning.md`** - Patching API (`workflow.GetVersion`), Worker Versioning
-- **`references/python/determinism-protection.md`** - Information on **`workflowcheck`** tool to help statically check for determinism issues.
+- **`references/go/determinism-protection.md`** - Information on **`workflowcheck`** tool to help statically check for determinism issues.


### PR DESCRIPTION
## What was changed

- Fix missing trailing `|` in `error-reference.md` table header (breaks Markdown table rendering)
- Fix wrong reference path in `go.md`: `references/python/determinism-protection.md` → `references/go/determinism-protection.md`
- Add missing `.md` extension to testing reference in `go/determinism-protection.md`
- Fix typos: "Activty" → "Activity", "accomplised" → "accomplished", "discourged" → "discouraged"

## Why?

The broken table header causes GitHub's Markdown renderer to not render the table properly. The wrong reference path in `go.md` points Go users to the Python determinism-protection doc instead of the Go one. The missing `.md` extension is inconsistent with all other reference links in the docs.

## Checklist

1. N/A (minor doc fixes)

2. How was this tested: Verified all referenced files exist and links are correct.

3. Any docs updates needed? No — these are the docs.