### PR TITLE
Add `@workflow.init` decorator to python.md Key Concepts

### DIFF
--- a/references/python/python.md
+++ b/references/python/python.md
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 
 ### Workflow Definition
 - Use `@workflow.defn` decorator on class
-- Use `@workflow.init` on `__init__` to receive workflow input and initialize state before `@workflow.run` or any signal/update handler is invoked
+- Put any state initialization logic in the `__init__` of your workflow class to guarantee that it happens before signals/updates arrive. If your state initialization logic requires the workflow parameters, then add the `@workflow.init` decorator and parameters to your `__init__`.
 - Use `@workflow.run` on the entry point method
 - Must be async (`async def`)
 - Use `@workflow.signal`, `@workflow.query`, `@workflow.update` for handlers


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added the new `@workflow.init` decorator to python.md.

## Why?
It was mentioned as being needed for Java [here](https://github.com/temporalio/skill-temporal-developer/pull/42#discussion_r2955189993), but it turns out to also be needed for Python. Adding for Java in the referenced PR.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
