### PR TITLE
Add skill to plugin syncing workflow

### DIFF
--- a/.github/workflows/sync-skill-to-plugins.yml
+++ b/.github/workflows/sync-skill-to-plugins.yml
@@ -14,6 +14,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-skill-to-plugins.yml
+++ b/.github/workflows/sync-skill-to-plugins.yml
@@ -1,0 +1,103 @@
+# ABOUTME: GitHub Actions workflow that syncs skill contents to the cursor and codex plugin repos.
+# ABOUTME: Triggers when a new release is created (by the package-skill workflow) or manually.
+# ABOUTME: Creates or updates a PR in each target repo rather than pushing directly to main.
+# ABOUTME: Uses a GitHub App for cross-repo authentication. Required secrets:
+# ABOUTME:   SKILL_T_DEV_APP_ID — the GitHub App's ID
+# ABOUTME:   SKILL_T_DEV_KEY    — the GitHub App's private key
+# ABOUTME: The app must be installed on all three repos with Contents (write) and
+# ABOUTME: Pull Requests (write) permissions.
+
+name: Sync Skill to Plugin Repos
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: temporalio/cursor-temporal-plugin
+            target_path: skills/temporal-developer
+          - repo: temporalio/codex-temporal-plugin
+            target_path: plugins/temporal-developer/skills/temporal-developer
+          - repo: temporalio/claude-temporal-plugin
+            target_path: skills/temporal-developer
+
+    steps:
+      - name: Generate token from GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SKILL_T_DEV_APP_ID }}
+          private-key: ${{ secrets.SKILL_T_DEV_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.repo }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: target-repo
+
+      - name: Sync skill contents
+        working-directory: target-repo
+        run: |
+          BRANCH="sync/temporal-developer-skill"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create or reset the sync branch based on current main.
+          # -B ensures the branch always starts from main's tip, even if a
+          # stale remote branch exists from a previously merged PR.
+          git checkout -B "$BRANCH" origin/main
+
+          # Remove old contents and copy current
+          rm -rf "${{ matrix.target_path }}/SKILL.md" \
+                 "${{ matrix.target_path }}/references"
+          cp ../SKILL.md "${{ matrix.target_path }}/"
+          cp -r ../references "${{ matrix.target_path }}/"
+
+          # Check for changes against main
+          git add "${{ matrix.target_path }}"
+          if git diff --cached --quiet; then
+            echo "no_changes=true" >> "$GITHUB_ENV"
+            echo "No changes to sync"
+          else
+            echo "no_changes=false" >> "$GITHUB_ENV"
+            version="${{ github.event.release.tag_name || 'manual' }}"
+            git commit -m "sync temporal-developer skill ${version} from source repo"
+            git push --force origin "$BRANCH"
+          fi
+
+      - name: Create or update PR
+        if: env.no_changes == 'false'
+        working-directory: target-repo
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="sync/temporal-developer-skill"
+          version="${{ github.event.release.tag_name || 'manual' }}"
+
+          # Check if a PR already exists from this branch
+          existing_pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+
+          if [ -n "$existing_pr" ]; then
+            echo "PR #${existing_pr} already exists — updated by the force-push"
+            gh pr comment "$existing_pr" --body "Updated to ${version} from [skill-temporal-developer](https://github.com/${{ github.repository }})."
+          else
+            body="Automated sync of the temporal-developer skill ${version} from [skill-temporal-developer](https://github.com/${{ github.repository }}).
+
+          This PR was created automatically by the [sync workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+            gh pr create \
+              --title "Sync temporal-developer skill ${version}" \
+              --body "$body"
+          fi


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adds `.github/workflows/sync-to-plugins.yml` to automate syncing of the skill content to harness plugin repos.

- When `main` receives a commit which bumps the `version` number in `SKILL.md` (or if triggered manually), the workflow will open / update a PR copying in the new skill content to these repos:
  + [https://github.com/temporalio/claude-temporal-plugin/tree/main/skills/temporal-developer](https://github.com/temporalio/claude-temporal-plugin/tree/main/skills/temporal-developer)
  + [https://github.com/temporalio/cursor-temporal-plugin/tree/main/skills/temporal-developer](https://github.com/temporalio/cursor-temporal-plugin/tree/main/skills/temporal-developer)
  + [https://github.com/temporalio/codex-temporal-plugin/tree/main/plugins/temporal-developer/skills/temporal-developer](https://github.com/temporalio/codex-temporal-plugin/tree/main/plugins/temporal-developer/skills/temporal-developer)

## Why?
This repo (skill-temporal-developer) should be treated as the single source of truth for skill content. This automation makes it easy to keep the plugin repos in sync with up-to-date skill content.

## Testing
- [ ] Merge, then test. For some reason GitHub isn't picking it up from this branch.
- [ ] Test manually invoking
- [ ] Test via version bumping after merging
