### PR TITLE
Update to latest versions of actions, to address deprecation warnings

### DIFF
--- a/.github/workflows/package-skill.yml
+++ b/.github/workflows/package-skill.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -44,14 +44,14 @@ jobs:
             -x '*.DS_Store'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: temporal-developer-skill
           path: temporal-developer-skill.zip
 
       - name: Create release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/sync-skill-to-plugins.yml
+++ b/.github/workflows/sync-skill-to-plugins.yml
@@ -34,17 +34,17 @@ jobs:
     steps:
       - name: Generate token from GitHub App
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.SKILL_T_DEV_APP_ID }}
           private-key: ${{ secrets.SKILL_T_DEV_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout target repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ matrix.repo }}
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What was changed
Update to latest versions of actions.

## Why?
Address GHA deprecation warnings for Node versions.

