### PR TITLE
Show RetryPolicy import in Python getting-started

### DIFF
--- a/references/python/python.md
+++ b/references/python/python.md
@@ -23,6 +23,7 @@ def greet(name: str) -> str:
 ```python
 from datetime import timedelta
 from temporalio import workflow
+from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
     from activities.greet import greet
@@ -32,9 +33,14 @@ class GreetingWorkflow:
     @workflow.run
     async def run(self, name: str) -> str:
         return await workflow.execute_activity(
-            greet, name, start_to_close_timeout=timedelta(seconds=30)
+            greet,
+            name,
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 ```
+
+Note the import paths: `workflow` (decorators, `execute_activity`, `logger`, etc.) lives in `temporalio.workflow`, but configuration types like `RetryPolicy` live in `temporalio.common` — not on the `workflow` module. The same applies to `SearchAttributeKey`, `VersioningBehavior`, and similar types.
 
 **worker.py** - Worker setup (registers activity and workflow, runs indefinitely and processes tasks):
 


### PR DESCRIPTION
## Summary

- Agents using this skill have produced `workflow.RetryPolicy(...)`, which fails with `module 'temporalio.workflow' has no attribute 'RetryPolicy'`.
- Root cause: `references/python/python.md` (the entry-point file SKILL.md tells agents to read first) only ever shows symbols from the `workflow` module — `workflow.defn`, `workflow.run`, `workflow.execute_activity`, `workflow.logger`, etc. — and never shows `retry_policy=` or the `temporalio.common` import. Agents pattern-match "Temporal things live on `workflow.*`" and hallucinate the namespace when they need a retry policy.
- Fix: extend the existing `execute_activity` example with a `retry_policy=RetryPolicy(...)` argument and the correct `from temporalio.common import RetryPolicy` import, plus a one-line note that configuration types (`RetryPolicy`, `SearchAttributeKey`, `VersioningBehavior`, ...) live in `temporalio.common`, not on the `workflow` module.

## Test plan

- [ ] Re-run the agent task that previously produced `workflow.RetryPolicy` and confirm it now imports `RetryPolicy` from `temporalio.common`.
- [ ] Skim the updated example for accuracy against the current `temporalio` SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)