### PR TITLE
Absorb CLI skill: workflow commands, dev server, CLI gotchas

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temporal-developer
-description: Develop, debug, and manage Temporal applications across Python, TypeScript, Go, Java and .NET. Use when the user is building workflows, activities, or workers with a Temporal SDK, debugging issues like non-determinism errors, stuck workflows, or activity retries, using Temporal CLI, Temporal Server, or Temporal Cloud, or working with durable execution concepts like signals, queries, heartbeats, versioning, continue-as-new, child workflows, or saga patterns.
+description: Develop, debug, and manage Temporal applications across Python, TypeScript, Go, Java and .NET. Use when the user is building workflows, activities, or workers with a Temporal SDK, debugging issues like non-determinism errors, stuck workflows, or activity retries, using Temporal CLI, Temporal Server, or Temporal Cloud, or working with durable execution concepts like signals, queries, heartbeats, versioning, continue-as-new, child workflows, or saga patterns. Also use when the user mentions "run a Temporal workflow from the CLI", "start a dev server", "run temporal server start-dev", "temporal workflow start", "temporal workflow execute", "temporal workflow signal", "temporal workflow query", "temporal workflow update".
 version: 0.4.0
 ---
 
@@ -74,6 +74,7 @@ Check if `temporal` CLI is installed. If not, follow the instructions at `refere
 - **`references/core/error-reference.md`** - Common error types, workflow status reference
 - **`references/core/interactive-workflows.md`** - Testing signals, updates, queries
 - **`references/core/dev-management.md`** - Dev cycle & management of server and workers
+- **`references/core/cli-workflow-commands.md`** - Developer-facing CLI commands for workflow interaction (start, execute, signal, query, update)
 - **`references/core/ai-patterns.md`** - AI/LLM pattern concepts
   - Language-specific info at `references/{your_language}/ai-patterns.md`, if available. Currently Python only.
 
@@ -93,6 +94,13 @@ Priority and Fairness also apply to tiered workloads (batch vs. real-time), weig
 ## Third-Party Integrations
 
 For Temporal plugins and integrations with third-party frameworks and SDKs (Spring Boot, Spring AI, OpenAI Agents SDK, Google ADK, etc.), see **`references/integrations.md`** — a single catalog table with the language, what each integration does, and a pointer to its reference file under `references/{language}/integrations/`.
+
+## Out of scope
+
+- **Operational CLI commands** (batch operations, health queries, Cloud admin, tcld, scripting) → `skill-temporal-ops`.
+- **Worker performance tuning, sizing, capacity planning** → `skill-temporal-workertuning`.
+
+If the conversation drifts into one of these areas, hand off to the relevant sibling skill rather than improvising.
 
 ## Feedback
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,13 +96,6 @@ Priority and Fairness also apply to tiered workloads (batch vs. real-time), weig
 
 For Temporal plugins and integrations with third-party frameworks and SDKs (Spring Boot, Spring AI, OpenAI Agents SDK, Google ADK, etc.), see **`references/integrations.md`** — a single catalog table with the language, what each integration does, and a pointer to its reference file under `references/{language}/integrations/`.
 
-## Out of scope of the `temporal-developer` skill
-
-- **Operational CLI commands** (batch operations, health queries, Cloud admin, tcld, scripting) → Use the `temporal-ops` skill.
-- **Worker performance tuning, sizing, capacity planning** → Use the `temporal-workertuning` skill.
-
-If the conversation drifts into one of these areas, hand off to the relevant sibling skill rather than improvising.
-
 ## Feedback
 
 ### Reporting Issues in This Skill

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,10 +96,10 @@ Priority and Fairness also apply to tiered workloads (batch vs. real-time), weig
 
 For Temporal plugins and integrations with third-party frameworks and SDKs (Spring Boot, Spring AI, OpenAI Agents SDK, Google ADK, etc.), see **`references/integrations.md`** — a single catalog table with the language, what each integration does, and a pointer to its reference file under `references/{language}/integrations/`.
 
-## Out of scope
+## Out of scope of the `temporal-developer` skill
 
-- **Operational CLI commands** (batch operations, health queries, Cloud admin, tcld, scripting) → `skill-temporal-ops`.
-- **Worker performance tuning, sizing, capacity planning** → `skill-temporal-workertuning`.
+- **Operational CLI commands** (batch operations, health queries, Cloud admin, tcld, scripting) → Use the `temporal-ops` skill.
+- **Worker performance tuning, sizing, capacity planning** → Use the `temporal-workertuning` skill.
 
 If the conversation drifts into one of these areas, hand off to the relevant sibling skill rather than improvising.
 

--- a/references/core/cli-workflow-commands.md
+++ b/references/core/cli-workflow-commands.md
@@ -69,11 +69,9 @@ temporal workflow execute \
     --input '{"some-key": "some-value"}'
 ```
 
-Accepts the same start-time flags as `workflow start`, plus `--detailed` (display events as sections rather than a table; not applied to JSON output). <!-- docs/cli/workflow.mdx:182 --> With `--output json`, the emitted blob includes the full `history` key for the run. <!-- docs/cli/workflow.mdx:175-176 -->
+Accepts the same start-time flags as `workflow start`. The only `workflow execute` specific flag is `--detailed` (display events as sections rather than a table; not applied to JSON output). With `--output json`, the emitted blob includes the full `history` key for the run.
 
 A non-zero exit code means the Workflow failed, was cancelled, terminated, or timed out. Useful for one-shot scripts and smoke tests during development.
-
-<!-- Sources: docs/cli/workflow.mdx:159-204 -->
 
 ## Workflow signal
 

--- a/references/core/cli-workflow-commands.md
+++ b/references/core/cli-workflow-commands.md
@@ -2,7 +2,7 @@
 
 Developer-facing CLI commands for interacting with workflows during development and testing. These commands work identically against a dev server, a self-hosted cluster, or Temporal Cloud -- only the connection descriptor changes.
 
-**IMPORTANT:** In order to make outputs of `temporal` CLI commands easier to read and parse, use the `--output json` flag. The below examples do not show it, for brevity, but generally you should use `--output json`.
+**IMPORTANT:** In order to make outputs of `temporal` CLI commands easier to read and parse, use the `--output json` flag.
 
 ## Table of contents
 
@@ -21,6 +21,7 @@ Start a new Workflow Execution asynchronously. Returns the Workflow ID and Run I
 
 ```bash
 temporal workflow start \
+    --output json \
     --workflow-id YourWorkflowId \
     --type YourWorkflow \
     --task-queue YourTaskQueue \
@@ -63,6 +64,7 @@ Start a Workflow Execution and block until it completes, streaming progress to s
 
 ```bash
 temporal workflow execute \
+    --output json \
     --workflow-id YourWorkflowId \
     --type YourWorkflow \
     --task-queue YourTaskQueue \
@@ -79,6 +81,7 @@ Send an asynchronous signal to a running Workflow Execution.
 
 ```bash
 temporal workflow signal \
+    --output json \
     --workflow-id YourWorkflowId \
     --name YourSignal \
     --input '{"YourInputKey": "YourInputValue"}'
@@ -101,6 +104,7 @@ Invoke a read-only query handler. Queries do not mutate workflow state and can r
 
 ```bash
 temporal workflow query \
+    --output json \
     --workflow-id YourWorkflowId \
     --name YourQueryType \
     --input '{"YourInputKey": "YourInputValue"}'
@@ -126,6 +130,7 @@ Initiate an update and wait for the validator to accept or reject it.
 
 ```bash
 temporal workflow update start \
+    --output json \
     --workflow-id YourWorkflowId \
     --name YourUpdate \
     --input '{"some-key": "some-value"}' \
@@ -150,6 +155,7 @@ Start an update and wait for it to complete or fail. Can also wait on an existin
 
 ```bash
 temporal workflow update execute \
+    --output json \
     --workflow-id YourWorkflowId \
     --name YourUpdate \
     --input '{"some-key": "some-value"}'
@@ -172,6 +178,7 @@ Wait for a previously started update to complete or fail, then print the result.
 
 ```bash
 temporal workflow update result \
+    --output json \
     --workflow-id YourWorkflowId \
     --update-id YourUpdateId
 ```
@@ -190,6 +197,7 @@ Inspect the current status of an update, including a result if it has finished.
 
 ```bash
 temporal workflow update describe \
+    --output json \
     --workflow-id YourWorkflowId \
     --update-id YourUpdateId
 ```
@@ -208,6 +216,7 @@ Atomically signal a Workflow Execution -- if the target run does not exist, a ne
 
 ```bash
 temporal workflow signal-with-start \
+    --output json \
     --signal-name YourSignal \
     --signal-input '{"some-key": "some-value"}' \
     --workflow-id YourWorkflowId \
@@ -236,6 +245,7 @@ Block until a running Workflow Execution completes, then print the result.
 
 ```bash
 temporal workflow result \
+    --output json \
     --workflow-id YourWorkflowId
 ```
 
@@ -252,6 +262,7 @@ Issue a query to read user-set summary and details metadata for a Workflow Execu
 
 ```bash
 temporal workflow metadata \
+    --output json \
     --workflow-id YourWorkflowId
 ```
 

--- a/references/core/cli-workflow-commands.md
+++ b/references/core/cli-workflow-commands.md
@@ -2,7 +2,7 @@
 
 Developer-facing CLI commands for interacting with workflows during development and testing. These commands work identically against a dev server, a self-hosted cluster, or Temporal Cloud -- only the connection descriptor changes.
 
-All facts in this file are transcribed from the upstream CLI docs. Each section ends with a `<!-- Sources: path:line -->` footer.
+**IMPORTANT:** In order to make outputs of `temporal` CLI commands easier to read and parse, use the `--output json` flag. The below examples do not show it, for brevity, but generally you should use `--output json`.
 
 ## Table of contents
 

--- a/references/core/cli-workflow-commands.md
+++ b/references/core/cli-workflow-commands.md
@@ -29,31 +29,31 @@ temporal workflow start \
 
 Required flags: `--type`, `--task-queue`. <!-- docs/cli/workflow.mdx:201,203 --> Optional `--workflow-id` -- the Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:582 -->
 
-| Flag | Accepted values / format | Purpose |
+| Flag | Required | Purpose |
 |---|---|---|
-| `--type` | string | Workflow Type name. Required. <!-- docs/cli/workflow.mdx:581 --> |
-| `--task-queue`, `-t` | string | Workflow Task queue. Required. <!-- docs/cli/workflow.mdx:579 --> |
-| `--workflow-id`, `-w` | string | Workflow ID. Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:582 --> |
-| `--input`, `-i` | JSON string | Input value. Repeatable for multiple args. Mutually exclusive with `--input-file`. <!-- docs/cli/workflow.mdx:568 --> |
-| `--input-file` | path | Read input from file(s). Repeatable. Mutually exclusive with `--input`. <!-- docs/cli/workflow.mdx:570 --> |
-| `--input-base64` | bool | Decode `--input` as base64 before sending. <!-- docs/cli/workflow.mdx:569 --> |
-| `--input-meta` | `KEY=VALUE` | Override payload metadata (e.g., `encoding=json/protobuf`). Repeatable. <!-- docs/cli/workflow.mdx:571 --> |
-| `--id-reuse-policy` | `AllowDuplicate`, `AllowDuplicateFailedOnly`, `RejectDuplicate`, `TerminateIfRunning` | How to reuse a previously-seen Workflow ID. <!-- docs/cli/workflow.mdx:567 --> |
-| `--id-conflict-policy` | `Fail`, `UseExisting`, `TerminateExisting` | How to resolve conflicts with a currently-running execution sharing the same Workflow ID. <!-- docs/cli/workflow.mdx:566 --> |
-| `--execution-timeout` | duration | Fail a Workflow Execution if it lasts longer than this. Includes retries and ContinueAsNew. <!-- docs/cli/workflow.mdx:561 --> |
-| `--run-timeout` | duration | Fail a single Workflow Run if it lasts longer than this. <!-- docs/cli/workflow.mdx:574 --> |
-| `--task-timeout` | duration | Start-to-close timeout for a Workflow Task. <!-- docs/cli/workflow.mdx:580 --> |
-| `--search-attribute` | `KEY=VALUE` (JSON values) | Set a search attribute at start time. Repeatable. <!-- docs/cli/workflow.mdx:575 --> |
-| `--memo` | `KEY="VALUE"` (JSON values) | Attach unindexed metadata. Repeatable. <!-- docs/cli/workflow.mdx:572 --> |
-| `--start-delay` | duration | Delay before starting. Cannot combine with `--cron`. If the Workflow receives a signal or update before this time, it starts immediately. <!-- docs/cli/workflow.mdx:576 --> |
-| `--cron` | cron string | Legacy cron schedule (prefer `temporal schedule create`). <!-- docs/cli/workflow.mdx:560 --> |
-| `--priority-key` | `1`-`5` (default `3`) | Lower numbers = higher priority. <!-- docs/cli/workflow.mdx:573 --> |
-| `--fairness-key` | string (max 64 bytes) | Proportional task dispatch grouping key. <!-- docs/cli/workflow.mdx:563 --> |
-| `--fairness-weight` | `0.001`-`1000` | Weight for this fairness key. Keys dispatched proportionally to their weights. <!-- docs/cli/workflow.mdx:564 --> |
-| `--static-summary` | Markdown string | Human-readable summary for UIs. Single line. _(Experimental)_ <!-- docs/cli/workflow.mdx:578 --> |
-| `--static-details` | Markdown string | Human-readable details for UIs. May be multiple lines. _(Experimental)_ <!-- docs/cli/workflow.mdx:577 --> |
-| `--fail-existing` | bool | Fail if the Workflow already exists. <!-- docs/cli/workflow.mdx:562 --> |
-| `--headers` | `KEY=VALUE` (JSON values) | Temporal workflow headers (not gRPC). Repeatable. <!-- docs/cli/workflow.mdx:565 --> |
+| `--type` | Yes | Workflow Type name. <!-- docs/cli/workflow.mdx:581 --> |
+| `--task-queue`, `-t` | Yes | Workflow Task queue. <!-- docs/cli/workflow.mdx:579 --> |
+| `--workflow-id`, `-w` | No | Workflow ID. Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:582 --> |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. Mutually exclusive with `--input-file`. <!-- docs/cli/workflow.mdx:568 --> |
+| `--input-file` | No | Read input from file(s). Repeatable. Mutually exclusive with `--input`. <!-- docs/cli/workflow.mdx:570 --> |
+| `--input-base64` | No | Decode `--input` as base64 before sending. <!-- docs/cli/workflow.mdx:569 --> |
+| `--input-meta` | No | Override payload metadata as `KEY=VALUE` (e.g., `encoding=json/protobuf`). Repeatable. <!-- docs/cli/workflow.mdx:571 --> |
+| `--id-reuse-policy` | No | How to reuse a previously-seen Workflow ID. Values: `AllowDuplicate`, `AllowDuplicateFailedOnly`, `RejectDuplicate`, `TerminateIfRunning`. <!-- docs/cli/workflow.mdx:567 --> |
+| `--id-conflict-policy` | No | How to resolve conflicts with a running execution sharing the same ID. Values: `Fail`, `UseExisting`, `TerminateExisting`. <!-- docs/cli/workflow.mdx:566 --> |
+| `--execution-timeout` | No | Fail a Workflow Execution if it lasts longer than this (duration). Includes retries and ContinueAsNew. <!-- docs/cli/workflow.mdx:561 --> |
+| `--run-timeout` | No | Fail a single Workflow Run if it lasts longer than this (duration). <!-- docs/cli/workflow.mdx:574 --> |
+| `--task-timeout` | No | Start-to-close timeout for a Workflow Task (duration). <!-- docs/cli/workflow.mdx:580 --> |
+| `--search-attribute` | No | Set a search attribute as `KEY=VALUE` (JSON values). Repeatable. <!-- docs/cli/workflow.mdx:575 --> |
+| `--memo` | No | Attach unindexed metadata as `KEY="VALUE"` (JSON values). Repeatable. <!-- docs/cli/workflow.mdx:572 --> |
+| `--start-delay` | No | Delay before starting (duration). Cannot combine with `--cron`. <!-- docs/cli/workflow.mdx:576 --> |
+| `--cron` | No | Legacy cron schedule (prefer `temporal schedule create`). <!-- docs/cli/workflow.mdx:560 --> |
+| `--priority-key` | No | Priority 1-5 (default 3). Lower = higher priority. <!-- docs/cli/workflow.mdx:573 --> |
+| `--fairness-key` | No | Proportional task dispatch grouping key (string, max 64 bytes). <!-- docs/cli/workflow.mdx:563 --> |
+| `--fairness-weight` | No | Weight for this fairness key (0.001-1000). Keys dispatched proportionally. <!-- docs/cli/workflow.mdx:564 --> |
+| `--static-summary` | No | Human-readable summary for UIs. Single line. _(Experimental)_ <!-- docs/cli/workflow.mdx:578 --> |
+| `--static-details` | No | Human-readable details for UIs. May be multi-line. _(Experimental)_ <!-- docs/cli/workflow.mdx:577 --> |
+| `--fail-existing` | No | Fail if the Workflow already exists. <!-- docs/cli/workflow.mdx:562 --> |
+| `--headers` | No | Temporal workflow headers as `KEY=VALUE` (JSON). Not gRPC headers. Repeatable. <!-- docs/cli/workflow.mdx:565 --> |
 
 <!-- Sources: docs/cli/workflow.mdx:544-582 -->
 

--- a/references/core/cli-workflow-commands.md
+++ b/references/core/cli-workflow-commands.md
@@ -1,0 +1,266 @@
+# CLI Workflow Commands for Developers
+
+Developer-facing CLI commands for interacting with workflows during development and testing. These commands work identically against a dev server, a self-hosted cluster, or Temporal Cloud -- only the connection descriptor changes.
+
+All facts in this file are transcribed from the upstream CLI docs. Each section ends with a `<!-- Sources: path:line -->` footer.
+
+## Table of contents
+
+- [Workflow start](#workflow-start)
+- [Workflow execute](#workflow-execute)
+- [Workflow signal](#workflow-signal)
+- [Workflow query](#workflow-query)
+- [Workflow update](#workflow-update)
+- [Workflow signal-with-start](#workflow-signal-with-start)
+- [Workflow result](#workflow-result)
+- [Workflow metadata](#workflow-metadata)
+
+## Workflow start
+
+Start a new Workflow Execution asynchronously. Returns the Workflow ID and Run ID.
+
+```bash
+temporal workflow start \
+    --workflow-id YourWorkflowId \
+    --type YourWorkflow \
+    --task-queue YourTaskQueue \
+    --input '{"some-key": "some-value"}'
+```
+
+Required flags: `--type`, `--task-queue`. <!-- docs/cli/workflow.mdx:201,203 --> Optional `--workflow-id` -- the Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:582 -->
+
+| Flag | Accepted values / format | Purpose |
+|---|---|---|
+| `--type` | string | Workflow Type name. Required. <!-- docs/cli/workflow.mdx:581 --> |
+| `--task-queue`, `-t` | string | Workflow Task queue. Required. <!-- docs/cli/workflow.mdx:579 --> |
+| `--workflow-id`, `-w` | string | Workflow ID. Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:582 --> |
+| `--input`, `-i` | JSON string | Input value. Repeatable for multiple args. Mutually exclusive with `--input-file`. <!-- docs/cli/workflow.mdx:568 --> |
+| `--input-file` | path | Read input from file(s). Repeatable. Mutually exclusive with `--input`. <!-- docs/cli/workflow.mdx:570 --> |
+| `--input-base64` | bool | Decode `--input` as base64 before sending. <!-- docs/cli/workflow.mdx:569 --> |
+| `--input-meta` | `KEY=VALUE` | Override payload metadata (e.g., `encoding=json/protobuf`). Repeatable. <!-- docs/cli/workflow.mdx:571 --> |
+| `--id-reuse-policy` | `AllowDuplicate`, `AllowDuplicateFailedOnly`, `RejectDuplicate`, `TerminateIfRunning` | How to reuse a previously-seen Workflow ID. <!-- docs/cli/workflow.mdx:567 --> |
+| `--id-conflict-policy` | `Fail`, `UseExisting`, `TerminateExisting` | How to resolve conflicts with a currently-running execution sharing the same Workflow ID. <!-- docs/cli/workflow.mdx:566 --> |
+| `--execution-timeout` | duration | Fail a Workflow Execution if it lasts longer than this. Includes retries and ContinueAsNew. <!-- docs/cli/workflow.mdx:561 --> |
+| `--run-timeout` | duration | Fail a single Workflow Run if it lasts longer than this. <!-- docs/cli/workflow.mdx:574 --> |
+| `--task-timeout` | duration | Start-to-close timeout for a Workflow Task. <!-- docs/cli/workflow.mdx:580 --> |
+| `--search-attribute` | `KEY=VALUE` (JSON values) | Set a search attribute at start time. Repeatable. <!-- docs/cli/workflow.mdx:575 --> |
+| `--memo` | `KEY="VALUE"` (JSON values) | Attach unindexed metadata. Repeatable. <!-- docs/cli/workflow.mdx:572 --> |
+| `--start-delay` | duration | Delay before starting. Cannot combine with `--cron`. If the Workflow receives a signal or update before this time, it starts immediately. <!-- docs/cli/workflow.mdx:576 --> |
+| `--cron` | cron string | Legacy cron schedule (prefer `temporal schedule create`). <!-- docs/cli/workflow.mdx:560 --> |
+| `--priority-key` | `1`-`5` (default `3`) | Lower numbers = higher priority. <!-- docs/cli/workflow.mdx:573 --> |
+| `--fairness-key` | string (max 64 bytes) | Proportional task dispatch grouping key. <!-- docs/cli/workflow.mdx:563 --> |
+| `--fairness-weight` | `0.001`-`1000` | Weight for this fairness key. Keys dispatched proportionally to their weights. <!-- docs/cli/workflow.mdx:564 --> |
+| `--static-summary` | Markdown string | Human-readable summary for UIs. Single line. _(Experimental)_ <!-- docs/cli/workflow.mdx:578 --> |
+| `--static-details` | Markdown string | Human-readable details for UIs. May be multiple lines. _(Experimental)_ <!-- docs/cli/workflow.mdx:577 --> |
+| `--fail-existing` | bool | Fail if the Workflow already exists. <!-- docs/cli/workflow.mdx:562 --> |
+| `--headers` | `KEY=VALUE` (JSON values) | Temporal workflow headers (not gRPC). Repeatable. <!-- docs/cli/workflow.mdx:565 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:544-582 -->
+
+## Workflow execute
+
+Start a Workflow Execution and block until it completes, streaming progress to stdout.
+
+```bash
+temporal workflow execute \
+    --workflow-id YourWorkflowId \
+    --type YourWorkflow \
+    --task-queue YourTaskQueue \
+    --input '{"some-key": "some-value"}'
+```
+
+Accepts the same start-time flags as `workflow start`, plus `--detailed` (display events as sections rather than a table; not applied to JSON output). <!-- docs/cli/workflow.mdx:182 --> With `--output json`, the emitted blob includes the full `history` key for the run. <!-- docs/cli/workflow.mdx:175-176 -->
+
+A non-zero exit code means the Workflow failed, was cancelled, terminated, or timed out. Useful for one-shot scripts and smoke tests during development.
+
+<!-- Sources: docs/cli/workflow.mdx:159-204 -->
+
+## Workflow signal
+
+Send an asynchronous signal to a running Workflow Execution.
+
+```bash
+temporal workflow signal \
+    --workflow-id YourWorkflowId \
+    --name YourSignal \
+    --input '{"YourInputKey": "YourInputValue"}'
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes (or `--query`) | Workflow ID. <!-- docs/cli/workflow.mdx:473 --> |
+| `--name` | Yes | Signal name. <!-- docs/cli/workflow.mdx:468 --> |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:464 --> |
+| `--run-id`, `-r` | No | Pin to a specific run. Only with `--workflow-id`. <!-- docs/cli/workflow.mdx:472 --> |
+
+For bulk signaling with `--query` (runs as a batch job), see skill-temporal-ops.
+
+<!-- Sources: docs/cli/workflow.mdx:443-474 -->
+
+## Workflow query
+
+Invoke a read-only query handler. Queries do not mutate workflow state and can run on both running and completed workflows.
+
+```bash
+temporal workflow query \
+    --workflow-id YourWorkflowId \
+    --name YourQueryType \
+    --input '{"YourInputKey": "YourInputValue"}'
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:365 --> |
+| `--name` | Yes | Query Type/Name. <!-- docs/cli/workflow.mdx:362 --> |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:358 --> |
+| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:364 --> |
+| `--reject-condition` | No | Reject queries based on Workflow state. Accepted values: `not_open`, `not_completed_cleanly`. <!-- docs/cli/workflow.mdx:363 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:339-365 -->
+
+## Workflow update
+
+Update is a command **group**, not a single command. It has four subcommands: `describe`, `execute`, `result`, `start`.
+
+### `temporal workflow update start`
+
+Initiate an update and wait for the validator to accept or reject it.
+
+```bash
+temporal workflow update start \
+    --workflow-id YourWorkflowId \
+    --name YourUpdate \
+    --input '{"some-key": "some-value"}' \
+    --wait-for-stage accepted
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:813 --> |
+| `--name` | Yes | Handler method name. <!-- docs/cli/workflow.mdx:809 --> |
+| `--wait-for-stage` | Yes | Update stage to wait for. The **only** accepted value is `accepted`. Required to allow a future CLI version to choose a default. <!-- docs/cli/workflow.mdx:812 --> |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:805 --> |
+| `--update-id` | No | Idempotency key. Defaults to a UUID. <!-- docs/cli/workflow.mdx:811 --> |
+| `--run-id`, `-r` | No | Run ID. If unset, targets the currently-running execution. <!-- docs/cli/workflow.mdx:810 --> |
+| `--first-execution-run-id` | No | Pin the update to the last execution in the chain started with this Run ID. <!-- docs/cli/workflow.mdx:803 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:785-813 -->
+
+### `temporal workflow update execute`
+
+Start an update and wait for it to complete or fail. Can also wait on an existing in-flight update by reusing its Update ID.
+
+```bash
+temporal workflow update execute \
+    --workflow-id YourWorkflowId \
+    --name YourUpdate \
+    --input '{"some-key": "some-value"}'
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:764 --> |
+| `--name` | Yes | Handler method name. <!-- docs/cli/workflow.mdx:761 --> |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:757 --> |
+| `--update-id` | No | Idempotency key. Defaults to a UUID. <!-- docs/cli/workflow.mdx:763 --> |
+| `--run-id`, `-r` | No | Run ID. If unset, targets the currently-running execution. <!-- docs/cli/workflow.mdx:762 --> |
+| `--first-execution-run-id` | No | Pin the update to the last execution in the chain started with this Run ID. <!-- docs/cli/workflow.mdx:755 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:738-764 -->
+
+### `temporal workflow update result`
+
+Wait for a previously started update to complete or fail, then print the result.
+
+```bash
+temporal workflow update result \
+    --workflow-id YourWorkflowId \
+    --update-id YourUpdateId
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:783 --> |
+| `--update-id` | Yes | Update ID. Must be unique per Workflow Execution. <!-- docs/cli/workflow.mdx:782 --> |
+| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:781 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:766-783 -->
+
+### `temporal workflow update describe`
+
+Inspect the current status of an update, including a result if it has finished.
+
+```bash
+temporal workflow update describe \
+    --workflow-id YourWorkflowId \
+    --update-id YourUpdateId
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:736 --> |
+| `--update-id` | Yes | Update ID. Must be unique per Workflow Execution. <!-- docs/cli/workflow.mdx:735 --> |
+| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:734 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:719-736 -->
+
+## Workflow signal-with-start
+
+Atomically signal a Workflow Execution -- if the target run does not exist, a new Workflow Execution is created first, then the signal is delivered.
+
+```bash
+temporal workflow signal-with-start \
+    --signal-name YourSignal \
+    --signal-input '{"some-key": "some-value"}' \
+    --workflow-id YourWorkflowId \
+    --type YourWorkflowType \
+    --task-queue YourTaskQueue \
+    --input '{"some-key": "some-value"}'
+```
+
+Takes `--signal-name` (required), `--signal-input`, plus all start-time flags from `workflow start`. <!-- docs/cli/workflow.mdx:516,520-522 -->
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--signal-name` | Yes | Signal name. <!-- docs/cli/workflow.mdx:516 --> |
+| `--signal-input` | No | Signal input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:512 --> |
+| `--type` | Yes | Workflow Type name. <!-- docs/cli/workflow.mdx:522 --> |
+| `--task-queue`, `-t` | Yes | Workflow Task queue. <!-- docs/cli/workflow.mdx:520 --> |
+| `--workflow-id`, `-w` | No | Workflow ID. Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:523 --> |
+
+All other start-time flags (`--input`, `--id-reuse-policy`, `--id-conflict-policy`, timeouts, `--search-attribute`, `--memo`, etc.) are accepted. See [Workflow start](#workflow-start) for the full flag table.
+
+<!-- Sources: docs/cli/workflow.mdx:476-523 -->
+
+## Workflow result
+
+Block until a running Workflow Execution completes, then print the result.
+
+```bash
+temporal workflow result \
+    --workflow-id YourWorkflowId
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:419 --> |
+| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:418 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:405-419 -->
+
+## Workflow metadata
+
+Issue a query to read user-set summary and details metadata for a Workflow Execution.
+
+```bash
+temporal workflow metadata \
+    --workflow-id YourWorkflowId
+```
+
+| Flag | Required | Purpose |
+|---|---|---|
+| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:324 --> |
+| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:323 --> |
+| `--reject-condition` | No | Reject queries based on Workflow state. Accepted values: `not_open`, `not_completed_cleanly`. <!-- docs/cli/workflow.mdx:322 --> |
+
+<!-- Sources: docs/cli/workflow.mdx:307-324 -->

--- a/references/core/cli-workflow-commands.md
+++ b/references/core/cli-workflow-commands.md
@@ -28,35 +28,33 @@ temporal workflow start \
     --input '{"some-key": "some-value"}'
 ```
 
-Required flags: `--type`, `--task-queue`. <!-- docs/cli/workflow.mdx:201,203 --> Optional `--workflow-id` -- the Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:582 -->
+Required flags: `--type`, `--task-queue`. Optional `--workflow-id` -- the Service generates a UUID if omitted.
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--type` | Yes | Workflow Type name. <!-- docs/cli/workflow.mdx:581 --> |
-| `--task-queue`, `-t` | Yes | Workflow Task queue. <!-- docs/cli/workflow.mdx:579 --> |
-| `--workflow-id`, `-w` | No | Workflow ID. Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:582 --> |
-| `--input`, `-i` | No | Input value (JSON). Repeatable. Mutually exclusive with `--input-file`. <!-- docs/cli/workflow.mdx:568 --> |
-| `--input-file` | No | Read input from file(s). Repeatable. Mutually exclusive with `--input`. <!-- docs/cli/workflow.mdx:570 --> |
-| `--input-base64` | No | Decode `--input` as base64 before sending. <!-- docs/cli/workflow.mdx:569 --> |
-| `--input-meta` | No | Override payload metadata as `KEY=VALUE` (e.g., `encoding=json/protobuf`). Repeatable. <!-- docs/cli/workflow.mdx:571 --> |
-| `--id-reuse-policy` | No | How to reuse a previously-seen Workflow ID. Values: `AllowDuplicate`, `AllowDuplicateFailedOnly`, `RejectDuplicate`, `TerminateIfRunning`. <!-- docs/cli/workflow.mdx:567 --> |
-| `--id-conflict-policy` | No | How to resolve conflicts with a running execution sharing the same ID. Values: `Fail`, `UseExisting`, `TerminateExisting`. <!-- docs/cli/workflow.mdx:566 --> |
-| `--execution-timeout` | No | Fail a Workflow Execution if it lasts longer than this (duration). Includes retries and ContinueAsNew. <!-- docs/cli/workflow.mdx:561 --> |
-| `--run-timeout` | No | Fail a single Workflow Run if it lasts longer than this (duration). <!-- docs/cli/workflow.mdx:574 --> |
-| `--task-timeout` | No | Start-to-close timeout for a Workflow Task (duration). <!-- docs/cli/workflow.mdx:580 --> |
-| `--search-attribute` | No | Set a search attribute as `KEY=VALUE` (JSON values). Repeatable. <!-- docs/cli/workflow.mdx:575 --> |
-| `--memo` | No | Attach unindexed metadata as `KEY="VALUE"` (JSON values). Repeatable. <!-- docs/cli/workflow.mdx:572 --> |
-| `--start-delay` | No | Delay before starting (duration). Cannot combine with `--cron`. <!-- docs/cli/workflow.mdx:576 --> |
-| `--cron` | No | Legacy cron schedule (prefer `temporal schedule create`). <!-- docs/cli/workflow.mdx:560 --> |
-| `--priority-key` | No | Priority 1-5 (default 3). Lower = higher priority. <!-- docs/cli/workflow.mdx:573 --> |
-| `--fairness-key` | No | Proportional task dispatch grouping key (string, max 64 bytes). <!-- docs/cli/workflow.mdx:563 --> |
-| `--fairness-weight` | No | Weight for this fairness key (0.001-1000). Keys dispatched proportionally. <!-- docs/cli/workflow.mdx:564 --> |
-| `--static-summary` | No | Human-readable summary for UIs. Single line. _(Experimental)_ <!-- docs/cli/workflow.mdx:578 --> |
-| `--static-details` | No | Human-readable details for UIs. May be multi-line. _(Experimental)_ <!-- docs/cli/workflow.mdx:577 --> |
-| `--fail-existing` | No | Fail if the Workflow already exists. <!-- docs/cli/workflow.mdx:562 --> |
-| `--headers` | No | Temporal workflow headers as `KEY=VALUE` (JSON). Not gRPC headers. Repeatable. <!-- docs/cli/workflow.mdx:565 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:544-582 -->
+| `--type` | Yes | Workflow Type name. |
+| `--task-queue`, `-t` | Yes | Workflow Task queue. |
+| `--workflow-id`, `-w` | No | Workflow ID. Service generates a UUID if omitted. |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. Mutually exclusive with `--input-file`. |
+| `--input-file` | No | Read input from file(s). Repeatable. Mutually exclusive with `--input`. |
+| `--input-base64` | No | Decode `--input` as base64 before sending. |
+| `--input-meta` | No | Override payload metadata as `KEY=VALUE` (e.g., `encoding=json/protobuf`). Repeatable. |
+| `--id-reuse-policy` | No | How to reuse a previously-seen Workflow ID. Values: `AllowDuplicate`, `AllowDuplicateFailedOnly`, `RejectDuplicate`, `TerminateIfRunning`. |
+| `--id-conflict-policy` | No | How to resolve conflicts with a running execution sharing the same ID. Values: `Fail`, `UseExisting`, `TerminateExisting`. |
+| `--execution-timeout` | No | Fail a Workflow Execution if it lasts longer than this (duration). Includes retries and ContinueAsNew. |
+| `--run-timeout` | No | Fail a single Workflow Run if it lasts longer than this (duration). |
+| `--task-timeout` | No | Start-to-close timeout for a Workflow Task (duration). |
+| `--search-attribute` | No | Set a search attribute as `KEY=VALUE` (JSON values). Repeatable. |
+| `--memo` | No | Attach unindexed metadata as `KEY="VALUE"` (JSON values). Repeatable. |
+| `--start-delay` | No | Delay before starting (duration). Cannot combine with `--cron`. |
+| `--cron` | No | Legacy cron schedule (prefer `temporal schedule create`). |
+| `--priority-key` | No | Priority 1-5 (default 3). Lower = higher priority. |
+| `--fairness-key` | No | Proportional task dispatch grouping key (string, max 64 bytes). |
+| `--fairness-weight` | No | Weight for this fairness key (0.001-1000). Keys dispatched proportionally. |
+| `--static-summary` | No | Human-readable summary for UIs. Single line. _(Experimental)_ |
+| `--static-details` | No | Human-readable details for UIs. May be multi-line. _(Experimental)_ |
+| `--fail-existing` | No | Fail if the Workflow already exists. |
+| `--headers` | No | Temporal workflow headers as `KEY=VALUE` (JSON). Not gRPC headers. Repeatable. |
 
 ## Workflow execute
 
@@ -89,14 +87,12 @@ temporal workflow signal \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes (or `--query`) | Workflow ID. <!-- docs/cli/workflow.mdx:473 --> |
-| `--name` | Yes | Signal name. <!-- docs/cli/workflow.mdx:468 --> |
-| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:464 --> |
-| `--run-id`, `-r` | No | Pin to a specific run. Only with `--workflow-id`. <!-- docs/cli/workflow.mdx:472 --> |
+| `--workflow-id`, `-w` | Yes (or `--query`) | Workflow ID. |
+| `--name` | Yes | Signal name. |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. |
+| `--run-id`, `-r` | No | Pin to a specific run. Only with `--workflow-id`. |
 
 For bulk signaling with `--query` (runs as a batch job), see skill-temporal-ops.
-
-<!-- Sources: docs/cli/workflow.mdx:443-474 -->
 
 ## Workflow query
 
@@ -112,13 +108,11 @@ temporal workflow query \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:365 --> |
-| `--name` | Yes | Query Type/Name. <!-- docs/cli/workflow.mdx:362 --> |
-| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:358 --> |
-| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:364 --> |
-| `--reject-condition` | No | Reject queries based on Workflow state. Accepted values: `not_open`, `not_completed_cleanly`. <!-- docs/cli/workflow.mdx:363 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:339-365 -->
+| `--workflow-id`, `-w` | Yes | Workflow ID. |
+| `--name` | Yes | Query Type/Name. |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. |
+| `--run-id`, `-r` | No | Run ID. |
+| `--reject-condition` | No | Reject queries based on Workflow state. Accepted values: `not_open`, `not_completed_cleanly`. |
 
 ## Workflow update
 
@@ -139,15 +133,13 @@ temporal workflow update start \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:813 --> |
-| `--name` | Yes | Handler method name. <!-- docs/cli/workflow.mdx:809 --> |
-| `--wait-for-stage` | Yes | Update stage to wait for. The **only** accepted value is `accepted`. Required to allow a future CLI version to choose a default. <!-- docs/cli/workflow.mdx:812 --> |
-| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:805 --> |
-| `--update-id` | No | Idempotency key. Defaults to a UUID. <!-- docs/cli/workflow.mdx:811 --> |
-| `--run-id`, `-r` | No | Run ID. If unset, targets the currently-running execution. <!-- docs/cli/workflow.mdx:810 --> |
-| `--first-execution-run-id` | No | Pin the update to the last execution in the chain started with this Run ID. <!-- docs/cli/workflow.mdx:803 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:785-813 -->
+| `--workflow-id`, `-w` | Yes | Workflow ID. |
+| `--name` | Yes | Handler method name. |
+| `--wait-for-stage` | Yes | Update stage to wait for. The **only** accepted value is `accepted`. Required to allow a future CLI version to choose a default. |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. |
+| `--update-id` | No | Idempotency key. Defaults to a UUID. |
+| `--run-id`, `-r` | No | Run ID. If unset, targets the currently-running execution. |
+| `--first-execution-run-id` | No | Pin the update to the last execution in the chain started with this Run ID. |
 
 ### `temporal workflow update execute`
 
@@ -163,14 +155,12 @@ temporal workflow update execute \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:764 --> |
-| `--name` | Yes | Handler method name. <!-- docs/cli/workflow.mdx:761 --> |
-| `--input`, `-i` | No | Input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:757 --> |
-| `--update-id` | No | Idempotency key. Defaults to a UUID. <!-- docs/cli/workflow.mdx:763 --> |
-| `--run-id`, `-r` | No | Run ID. If unset, targets the currently-running execution. <!-- docs/cli/workflow.mdx:762 --> |
-| `--first-execution-run-id` | No | Pin the update to the last execution in the chain started with this Run ID. <!-- docs/cli/workflow.mdx:755 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:738-764 -->
+| `--workflow-id`, `-w` | Yes | Workflow ID. |
+| `--name` | Yes | Handler method name. |
+| `--input`, `-i` | No | Input value (JSON). Repeatable. |
+| `--update-id` | No | Idempotency key. Defaults to a UUID. |
+| `--run-id`, `-r` | No | Run ID. If unset, targets the currently-running execution. |
+| `--first-execution-run-id` | No | Pin the update to the last execution in the chain started with this Run ID. |
 
 ### `temporal workflow update result`
 
@@ -185,11 +175,9 @@ temporal workflow update result \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:783 --> |
-| `--update-id` | Yes | Update ID. Must be unique per Workflow Execution. <!-- docs/cli/workflow.mdx:782 --> |
-| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:781 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:766-783 -->
+| `--workflow-id`, `-w` | Yes | Workflow ID. |
+| `--update-id` | Yes | Update ID. Must be unique per Workflow Execution. |
+| `--run-id`, `-r` | No | Run ID. |
 
 ### `temporal workflow update describe`
 
@@ -204,11 +192,9 @@ temporal workflow update describe \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:736 --> |
-| `--update-id` | Yes | Update ID. Must be unique per Workflow Execution. <!-- docs/cli/workflow.mdx:735 --> |
-| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:734 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:719-736 -->
+| `--workflow-id`, `-w` | Yes | Workflow ID. |
+| `--update-id` | Yes | Update ID. Must be unique per Workflow Execution. |
+| `--run-id`, `-r` | No | Run ID. |
 
 ## Workflow signal-with-start
 
@@ -225,19 +211,17 @@ temporal workflow signal-with-start \
     --input '{"some-key": "some-value"}'
 ```
 
-Takes `--signal-name` (required), `--signal-input`, plus all start-time flags from `workflow start`. <!-- docs/cli/workflow.mdx:516,520-522 -->
+Takes `--signal-name` (required), `--signal-input`, plus all start-time flags from `workflow start`.
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--signal-name` | Yes | Signal name. <!-- docs/cli/workflow.mdx:516 --> |
-| `--signal-input` | No | Signal input value (JSON). Repeatable. <!-- docs/cli/workflow.mdx:512 --> |
-| `--type` | Yes | Workflow Type name. <!-- docs/cli/workflow.mdx:522 --> |
-| `--task-queue`, `-t` | Yes | Workflow Task queue. <!-- docs/cli/workflow.mdx:520 --> |
-| `--workflow-id`, `-w` | No | Workflow ID. Service generates a UUID if omitted. <!-- docs/cli/workflow.mdx:523 --> |
+| `--signal-name` | Yes | Signal name. |
+| `--signal-input` | No | Signal input value (JSON). Repeatable. |
+| `--type` | Yes | Workflow Type name. |
+| `--task-queue`, `-t` | Yes | Workflow Task queue. |
+| `--workflow-id`, `-w` | No | Workflow ID. Service generates a UUID if omitted. |
 
 All other start-time flags (`--input`, `--id-reuse-policy`, `--id-conflict-policy`, timeouts, `--search-attribute`, `--memo`, etc.) are accepted. See [Workflow start](#workflow-start) for the full flag table.
-
-<!-- Sources: docs/cli/workflow.mdx:476-523 -->
 
 ## Workflow result
 
@@ -251,10 +235,8 @@ temporal workflow result \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:419 --> |
-| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:418 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:405-419 -->
+| `--workflow-id`, `-w` | Yes | Workflow ID. |
+| `--run-id`, `-r` | No | Run ID. |
 
 ## Workflow metadata
 
@@ -268,8 +250,6 @@ temporal workflow metadata \
 
 | Flag | Required | Purpose |
 |---|---|---|
-| `--workflow-id`, `-w` | Yes | Workflow ID. <!-- docs/cli/workflow.mdx:324 --> |
-| `--run-id`, `-r` | No | Run ID. <!-- docs/cli/workflow.mdx:323 --> |
-| `--reject-condition` | No | Reject queries based on Workflow state. Accepted values: `not_open`, `not_completed_cleanly`. <!-- docs/cli/workflow.mdx:322 --> |
-
-<!-- Sources: docs/cli/workflow.mdx:307-324 -->
+| `--workflow-id`, `-w` | Yes | Workflow ID. |
+| `--run-id`, `-r` | No | Run ID. |
+| `--reject-condition` | No | Reject queries based on Workflow state. Accepted values: `not_open`, `not_completed_cleanly`. |

--- a/references/core/dev-management.md
+++ b/references/core/dev-management.md
@@ -25,8 +25,8 @@ The dev server is for local development only, not production. <!-- docs/cli/serv
 | `--ui-port` | `--port` + 1000 | Web UI port. <!-- docs/cli/server.mdx:83 --> |
 | `--ip` | `127.0.0.1` | IP address bound to the front-end service. Use `0.0.0.0` for Docker/LAN access. <!-- docs/cli/server.mdx:73 --> |
 | `--dynamic-config-value` | — | Dynamic config in `KEY=JSON_VALUE` form. Repeatable. <!-- docs/cli/server.mdx:70 --> |
-| `--log-level` | `warn` | Log level. Accepted values: `debug`, `info`, `warn`, `error`, `never`. <!-- docs/cli/server.mdx:109 --> |
-| `--log-format` | `text` | Log format. Accepted values: `text`, `json`. <!-- docs/cli/server.mdx:108 --> |
+| `--log-level` | `warn` | (Global flag) Log level. Accepted values: `debug`, `info`, `warn`, `error`, `never`. Default is `warn` for `start-dev`. <!-- docs/cli/server.mdx:109 --> |
+| `--log-format` | `text` | (Global flag) Log format. Accepted values: `text`, `json`. <!-- docs/cli/server.mdx:108 --> |
 | `--headless` | — | Disable the Web UI. <!-- docs/cli/server.mdx:71 --> |
 | `--http-port` | random free port | HTTP API port. <!-- docs/cli/server.mdx:72 --> |
 | `--metrics-port` | random free port | Prometheus `/metrics` port. <!-- docs/cli/server.mdx:75 --> |

--- a/references/core/dev-management.md
+++ b/references/core/dev-management.md
@@ -10,26 +10,26 @@ temporal server start-dev # Start this in the background.
 
 The dev server can be shared across projects and left running as you develop.
 
-The dev server is in-memory by default -- all workflows, schedules, and history are lost on restart. Use `--db-filename temporal.db` to persist across restarts. <!-- docs/cli/server.mdx:69 -->
+The dev server is in-memory by default -- all workflows, schedules, and history are lost on restart. Use `--db-filename temporal.db` to persist across restarts.
 
-The dev server is for local development only, not production. <!-- docs/cli/server.mdx:28-35 -->
+The dev server is for local development only, not production.
 
 ### `temporal server start-dev` flags
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `--db-filename`, `-f` | in-memory | Persistent SQLite file. Without it, state is in-memory and lost on exit. <!-- docs/cli/server.mdx:69 --> |
-| `--namespace`, `-n` | `default` only | Namespaces to create at launch. Repeatable. The `default` namespace is always created. <!-- docs/cli/server.mdx:76 --> |
-| `--search-attribute` | — | Register search attributes as `KEY=TYPE` pairs. TYPE is one of: `Text`, `Keyword`, `Int`, `Double`, `Bool`, `Datetime`, `KeywordList`. Repeatable. <!-- docs/cli/server.mdx:78 --> |
-| `--port`, `-p` | `7233` | Front-end gRPC port. <!-- docs/cli/server.mdx:77 --> |
-| `--ui-port` | `--port` + 1000 | Web UI port. <!-- docs/cli/server.mdx:83 --> |
-| `--ip` | `127.0.0.1` | IP address bound to the front-end service. Use `0.0.0.0` for Docker/LAN access. <!-- docs/cli/server.mdx:73 --> |
-| `--dynamic-config-value` | — | Dynamic config in `KEY=JSON_VALUE` form. Repeatable. <!-- docs/cli/server.mdx:70 --> |
-| `--log-level` | `warn` | (Global flag) Log level. Accepted values: `debug`, `info`, `warn`, `error`, `never`. Default is `warn` for `start-dev`. <!-- docs/cli/server.mdx:109 --> |
-| `--log-format` | `text` | (Global flag) Log format. Accepted values: `text`, `json`. <!-- docs/cli/server.mdx:108 --> |
-| `--headless` | — | Disable the Web UI. <!-- docs/cli/server.mdx:71 --> |
-| `--http-port` | random free port | HTTP API port. <!-- docs/cli/server.mdx:72 --> |
-| `--metrics-port` | random free port | Prometheus `/metrics` port. <!-- docs/cli/server.mdx:75 --> |
+| `--db-filename`, `-f` | in-memory | Persistent SQLite file. Without it, state is in-memory and lost on exit. |
+| `--namespace`, `-n` | `default` only | Namespaces to create at launch. Repeatable. The `default` namespace is always created. |
+| `--search-attribute` | — | Register search attributes as `KEY=TYPE` pairs. TYPE is one of: `Text`, `Keyword`, `Int`, `Double`, `Bool`, `Datetime`, `KeywordList`. Repeatable. |
+| `--port`, `-p` | `7233` | Front-end gRPC port. |
+| `--ui-port` | `--port` + 1000 | Web UI port. |
+| `--ip` | `127.0.0.1` | IP address bound to the front-end service. Use `0.0.0.0` for Docker/LAN access. |
+| `--dynamic-config-value` | — | Dynamic config in `KEY=JSON_VALUE` form. Repeatable. |
+| `--log-level` | `warn` | (Global flag) Log level. Accepted values: `debug`, `info`, `warn`, `error`, `never`. Default is `warn` for `start-dev`. |
+| `--log-format` | `text` | (Global flag) Log format. Accepted values: `text`, `json`. |
+| `--headless` | — | Disable the Web UI. |
+| `--http-port` | random free port | HTTP API port. |
+| `--metrics-port` | random free port | Prometheus `/metrics` port. |
 
 Example with persistence, extra namespaces, and a search attribute:
 
@@ -39,8 +39,6 @@ temporal server start-dev \
     --namespace dev \
     --search-attribute OrderId=Keyword
 ```
-
-<!-- Sources: docs/cli/server.mdx:23-109 -->
 
 ## Worker Management Details
 
@@ -66,8 +64,6 @@ Steps to promote a workflow from a local dev server to a production backend. The
 temporal server start-dev --db-filename dev.db
 ```
 
-<!-- Sources: docs/cli/server.mdx:23-69 -->
-
 ### 2. Run the workflow against dev
 
 Start your worker, then execute the workflow:
@@ -79,7 +75,7 @@ temporal workflow execute \
     --input '{"key": "value"}'
 ```
 
-`workflow execute` blocks until the run terminates; a non-zero exit means the run failed, was cancelled, terminated, or timed out. <!-- docs/cli/workflow.mdx:159-204 -->
+`workflow execute` blocks until the run terminates; a non-zero exit means the run failed, was cancelled, terminated, or timed out.
 
 ### 3. Create a prod stored environment
 
@@ -89,7 +85,7 @@ temporal env set prod.namespace "your-ns.your-acct"
 temporal env set prod.api-key   "your-key"
 ```
 
-The environment-selecting flag is `--env <name>` (env var `TEMPORAL_ENV`). <!-- docs/cli/env.mdx:27-110 -->
+The environment-selecting flag is `--env <name>` (env var `TEMPORAL_ENV`).
 
 ### 4. Smoke-test prod
 
@@ -97,7 +93,7 @@ The environment-selecting flag is `--env <name>` (env var `TEMPORAL_ENV`). <!-- 
 temporal workflow list --env prod --limit 1
 ```
 
-If this returns (even an empty list), the connection descriptor is correct. <!-- docs/cli/index.mdx:358-362 -->
+If this returns (even an empty list), the connection descriptor is correct.
 
 ### 5. Run in prod
 
@@ -109,6 +105,6 @@ temporal workflow start \
     --input '{"key": "value"}'
 ```
 
-`workflow start` is asynchronous (returns a Workflow/Run ID); use `workflow execute` instead if you want the CLI to block. <!-- docs/cli/workflow.mdx:544-582 -->
+`workflow start` is asynchronous (returns a Workflow/Run ID); use `workflow execute` instead if you want the CLI to block.
 
 For stored environment details, see skill-temporal-ops `cli-scripting.md`.

--- a/references/core/dev-management.md
+++ b/references/core/dev-management.md
@@ -10,6 +10,38 @@ temporal server start-dev # Start this in the background.
 
 It is perfectly OK for this process to be shared across multiple projects / left running as you develop your Temporal code.
 
+The dev server is in-memory by default -- all workflows, schedules, and history are lost on restart. Use `--db-filename temporal.db` to persist across restarts. <!-- docs/cli/server.mdx:69 -->
+
+The dev server is for local development only, not production. <!-- docs/cli/server.mdx:28-35 -->
+
+### `temporal server start-dev` flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--db-filename`, `-f` | in-memory | Persistent SQLite file. Without it, state is in-memory and lost on exit. <!-- docs/cli/server.mdx:69 --> |
+| `--namespace`, `-n` | `default` only | Namespaces to create at launch. Repeatable. The `default` namespace is always created. <!-- docs/cli/server.mdx:76 --> |
+| `--search-attribute` | — | Register search attributes as `KEY=TYPE` pairs. TYPE is one of: `Text`, `Keyword`, `Int`, `Double`, `Bool`, `Datetime`, `KeywordList`. Repeatable. <!-- docs/cli/server.mdx:78 --> |
+| `--port`, `-p` | `7233` | Front-end gRPC port. <!-- docs/cli/server.mdx:77 --> |
+| `--ui-port` | `--port` + 1000 | Web UI port. <!-- docs/cli/server.mdx:83 --> |
+| `--ip` | `127.0.0.1` | IP address bound to the front-end service. Use `0.0.0.0` for Docker/LAN access. <!-- docs/cli/server.mdx:73 --> |
+| `--dynamic-config-value` | — | Dynamic config in `KEY=JSON_VALUE` form. Repeatable. <!-- docs/cli/server.mdx:70 --> |
+| `--log-level` | `warn` | Log level. Accepted values: `debug`, `info`, `warn`, `error`, `never`. <!-- docs/cli/server.mdx:109 --> |
+| `--log-format` | `text` | Log format. Accepted values: `text`, `json`. <!-- docs/cli/server.mdx:108 --> |
+| `--headless` | — | Disable the Web UI. <!-- docs/cli/server.mdx:71 --> |
+| `--http-port` | random free port | HTTP API port. <!-- docs/cli/server.mdx:72 --> |
+| `--metrics-port` | random free port | Prometheus `/metrics` port. <!-- docs/cli/server.mdx:75 --> |
+
+Example with persistence, extra namespaces, and a search attribute:
+
+```bash
+temporal server start-dev \
+    --db-filename /tmp/temporal.db \
+    --namespace dev \
+    --search-attribute OrderId=Keyword
+```
+
+<!-- Sources: docs/cli/server.mdx:23-109 -->
+
 ## Worker Management Details
 
 ### Starting Workers
@@ -23,3 +55,60 @@ When you need a new worker, you should start it in the background (and preferrab
 ### Cleanup
 
 **Always kill workers when done.** Don't leave workers running.
+
+## Dev to Prod
+
+Steps to promote a workflow from a local dev server to a production backend. The workflow and worker code do not change between environments; only the connection descriptor does.
+
+### 1. Start a local dev server with persistence
+
+```bash
+temporal server start-dev --db-filename dev.db
+```
+
+<!-- Sources: docs/cli/server.mdx:23-69 -->
+
+### 2. Run the workflow against dev
+
+Start your worker, then execute the workflow:
+
+```bash
+temporal workflow execute \
+    --type MyWorkflow \
+    --task-queue my-queue \
+    --input '{"key": "value"}'
+```
+
+`workflow execute` blocks until the run terminates; a non-zero exit means the run failed, was cancelled, terminated, or timed out. <!-- docs/cli/workflow.mdx:159-204 -->
+
+### 3. Create a prod stored environment
+
+```bash
+temporal env set prod.address   "your-ns.your-acct.tmprl.cloud:7233"
+temporal env set prod.namespace "your-ns.your-acct"
+temporal env set prod.api-key   "your-key"
+```
+
+The environment-selecting flag is `--env <name>` (env var `TEMPORAL_ENV`). <!-- docs/cli/env.mdx:27-110 -->
+
+### 4. Smoke-test prod
+
+```bash
+temporal workflow list --env prod --limit 1
+```
+
+If this returns (even an empty list), the connection descriptor is correct. <!-- docs/cli/index.mdx:358-362 -->
+
+### 5. Run in prod
+
+```bash
+temporal workflow start \
+    --env prod \
+    --type MyWorkflow \
+    --task-queue my-queue \
+    --input '{"key": "value"}'
+```
+
+`workflow start` is asynchronous (returns a Workflow/Run ID); use `workflow execute` instead if you want the CLI to block. <!-- docs/cli/workflow.mdx:544-582 -->
+
+For stored environment details, see skill-temporal-ops `cli-scripting.md`.

--- a/references/core/dev-management.md
+++ b/references/core/dev-management.md
@@ -90,7 +90,7 @@ The environment-selecting flag is `--env <name>` (env var `TEMPORAL_ENV`).
 ### 4. Smoke-test prod
 
 ```bash
-temporal workflow list --env prod --limit 1
+temporal workflow list --env prod --limit 1 --output json
 ```
 
 If this returns (even an empty list), the connection descriptor is correct.

--- a/references/core/dev-management.md
+++ b/references/core/dev-management.md
@@ -56,7 +56,7 @@ When you need a new worker, you should start it in the background (and preferrab
 
 ## Dev to Prod
 
-Steps to promote a workflow from a local dev server to a production backend. The workflow and worker code do not change between environments; only the connection descriptor does.
+Steps to promote a workflow from a local dev server to a production backend. For the most part, the workflow and worker code do not change between environments; only the connection descriptor does. If the connection code is in the application code, then just those spots in the code need to be updated.
 
 ### 1. Start a local dev server with persistence
 

--- a/references/core/dev-management.md
+++ b/references/core/dev-management.md
@@ -77,20 +77,20 @@ temporal workflow execute \
 
 `workflow execute` blocks until the run terminates; a non-zero exit means the run failed, was cancelled, terminated, or timed out.
 
-### 3. Create a prod stored environment
+### 3. Create a prod profile configuration
 
 ```bash
-temporal env set prod.address   "your-ns.your-acct.tmprl.cloud:7233"
-temporal env set prod.namespace "your-ns.your-acct"
-temporal env set prod.api-key   "your-key"
+temporal config --profile prod set --prop address --value "your-ns.your-acct.tmprl.cloud:7233"
+temporal config --profile prod set --prop namespace --value "your-ns.your-acct"
+temporal config --profile prod set --prop api-key --value "your-key"
 ```
 
-The environment-selecting flag is `--env <name>` (env var `TEMPORAL_ENV`).
+The profile-selecting flag is `--profile <name>`.
 
 ### 4. Smoke-test prod
 
 ```bash
-temporal workflow list --env prod --limit 1 --output json
+temporal workflow list --profile prod --limit 1 --output json
 ```
 
 If this returns (even an empty list), the connection descriptor is correct.
@@ -99,12 +99,10 @@ If this returns (even an empty list), the connection descriptor is correct.
 
 ```bash
 temporal workflow start \
-    --env prod \
+    --profile prod \
     --type MyWorkflow \
     --task-queue my-queue \
     --input '{"key": "value"}'
 ```
 
 `workflow start` is asynchronous (returns a Workflow/Run ID); use `workflow execute` instead if you want the CLI to block.
-
-For stored environment details, see skill-temporal-ops `cli-scripting.md`.

--- a/references/core/dev-management.md
+++ b/references/core/dev-management.md
@@ -2,13 +2,13 @@
 
 ## Server Management
 
-Before starting workers or workflows, you MUST start a local dev server, using the Temporal CLI:
+Workers and workflows need a running Temporal Server. You can develop against a local dev server, a self-hosted cluster, or Temporal Cloud — the choice depends on your setup. If you need a local server, start one with the Temporal CLI:
 
 ```bash
 temporal server start-dev # Start this in the background.
 ```
 
-It is perfectly OK for this process to be shared across multiple projects / left running as you develop your Temporal code.
+The dev server can be shared across projects and left running as you develop.
 
 The dev server is in-memory by default -- all workflows, schedules, and history are lost on restart. Use `--db-filename temporal.db` to persist across restarts. <!-- docs/cli/server.mdx:69 -->
 

--- a/references/core/gotchas.md
+++ b/references/core/gotchas.md
@@ -205,18 +205,18 @@ The dev server loses all state on restart (use `--db-filename` to persist) and r
 
 Running `temporal workflow update` alone will not work. Use the correct subcommand:
 
-- `temporal workflow update execute` -- start an update and wait for completion. <!-- docs/cli/workflow.mdx:738-764 -->
-- `temporal workflow update start` -- fire an update and wait for acceptance. Requires `--wait-for-stage accepted`. <!-- docs/cli/workflow.mdx:785-813 -->
-- `temporal workflow update result` -- get the result of a previously started update. <!-- docs/cli/workflow.mdx:766-783 -->
-- `temporal workflow update describe` -- check an update's current status. <!-- docs/cli/workflow.mdx:719-736 -->
+- `temporal workflow update execute` -- start an update and wait for completion.
+- `temporal workflow update start` -- fire an update and wait for acceptance. Requires `--wait-for-stage accepted`.
+- `temporal workflow update result` -- get the result of a previously started update.
+- `temporal workflow update describe` -- check an update's current status.
 
 ### `--wait-for-stage` Only Accepts `accepted`
 
-Despite looking like an enum, the only valid value for `--wait-for-stage` on `temporal workflow update start` is `accepted`. <!-- docs/cli/workflow.mdx:812 --> Passing `completed` or other values will fail. The flag is required to allow a future CLI version to choose a default.
+Despite looking like an enum, the only valid value for `--wait-for-stage` on `temporal workflow update start` is `accepted`. Passing `completed` or other values will fail. The flag is required to allow a future CLI version to choose a default.
 
 ### `--reapply-type` Only Accepts `Signal` or `None`
 
-When resetting a workflow with `temporal workflow reset`, `--reapply-type` controls which events get reapplied after the reset point. Only `Signal` and `None` are valid values. <!-- docs/cli/cmd-options.mdx:497 -->
+When resetting a workflow with `temporal workflow reset`, `--reapply-type` controls which events get reapplied after the reset point. Only `Signal` and `None` are valid values.
 
 ## Payload Size Limits
 

--- a/references/core/gotchas.md
+++ b/references/core/gotchas.md
@@ -199,7 +199,7 @@ See language-specific gotchas for details.
 
 ### Dev Server Is In-Memory and Not for Production
 
-The dev server loses all state on restart (use `--db-filename` to persist) and runs everything in a single process. See `dev-management.md` for the full flag table and persistence guidance.
+The dev server loses all state on restart (use `--db-filename` to persist) and runs everything in a single process. See `dev-management.md` for the full flag table and persistence guidance. Even with persistence enabled, the dev server should NEVER be used for production deployments.
 
 ### `workflow update` Is a Command Group, Not a Single Command
 

--- a/references/core/gotchas.md
+++ b/references/core/gotchas.md
@@ -195,6 +195,33 @@ See language-specific gotchas for details.
 
 **The Fix**: Heartbeat regularly and check for cancellation. See language-specific gotchas for implementation patterns.
 
+## CLI Gotchas for Developers
+
+### Dev Server Is In-Memory by Default
+
+All workflows, schedules, and history vanish on restart. Use `--db-filename temporal.db` for persistence. <!-- docs/cli/server.mdx:69 --> Do not rely on dev server state across restarts.
+
+### Dev Server Is Not for Production
+
+The dev server runs all services in a single process with no replication. Use Temporal Cloud or a self-hosted cluster for production. <!-- docs/cli/server.mdx:28-35 -->
+
+### `workflow update` Is a Command Group, Not a Single Command
+
+Running `temporal workflow update` alone will not work. Use the correct subcommand:
+
+- `temporal workflow update execute` -- start an update and wait for completion. <!-- docs/cli/workflow.mdx:738-764 -->
+- `temporal workflow update start` -- fire an update and wait for acceptance. Requires `--wait-for-stage accepted`. <!-- docs/cli/workflow.mdx:785-813 -->
+- `temporal workflow update result` -- get the result of a previously started update. <!-- docs/cli/workflow.mdx:766-783 -->
+- `temporal workflow update describe` -- check an update's current status. <!-- docs/cli/workflow.mdx:719-736 -->
+
+### `--wait-for-stage` Only Accepts `accepted`
+
+Despite looking like an enum, the only valid value for `--wait-for-stage` on `temporal workflow update start` is `accepted`. <!-- docs/cli/workflow.mdx:812 --> Passing `completed` or other values will fail. The flag is required to allow a future CLI version to choose a default.
+
+### `--reapply-type` Only Accepts `Signal` or `None`
+
+When resetting a workflow with `temporal workflow reset`, `--reapply-type` controls which events get reapplied after the reset point. Only `Signal` and `None` are valid values. <!-- docs/cli/cmd-options.mdx:497 -->
+
 ## Payload Size Limits
 
 **The Problem**: Temporal has built-in limits on payload sizes. Exceeding them causes workflows to fail.

--- a/references/core/gotchas.md
+++ b/references/core/gotchas.md
@@ -197,13 +197,9 @@ See language-specific gotchas for details.
 
 ## CLI Gotchas for Developers
 
-### Dev Server Is In-Memory by Default
+### Dev Server Is In-Memory and Not for Production
 
-All workflows, schedules, and history vanish on restart. Use `--db-filename temporal.db` for persistence. <!-- docs/cli/server.mdx:69 --> Do not rely on dev server state across restarts.
-
-### Dev Server Is Not for Production
-
-The dev server runs all services in a single process with no replication. Use Temporal Cloud or a self-hosted cluster for production. <!-- docs/cli/server.mdx:28-35 -->
+The dev server loses all state on restart (use `--db-filename` to persist) and runs everything in a single process. See `dev-management.md` for the full flag table and persistence guidance.
 
 ### `workflow update` Is a Command Group, Not a Single Command
 

--- a/references/core/install_cli.md
+++ b/references/core/install_cli.md
@@ -1,25 +1,60 @@
 # How to install Temporal CLI
 
+<!-- Source: docs/cli/setup-cli.mdx (Install the CLI) -->
+
 ## macOS
 
-```
+Homebrew or CDN tarball:
+
+```bash
 brew install temporal
 ```
 
+- [Darwin amd64](https://temporal.download/cli/archive/latest?platform=darwin&arch=amd64)
+- [Darwin arm64](https://temporal.download/cli/archive/latest?platform=darwin&arch=arm64)
+
+Extract any downloaded archive and add the `temporal` binary to your `PATH`. <!-- docs/cli/setup-cli.mdx:46 -->
+
 ## Linux
 
-Check your machine's architecture and download the appropriate archive:
+Homebrew (if available), Snap, or CDN tarball: <!-- docs/cli/setup-cli.mdx:55-60 -->
+
+```bash
+brew install temporal
+# or
+snap install temporal
+```
 
 - [Linux amd64](https://temporal.download/cli/archive/latest?platform=linux&arch=amd64)
 - [Linux arm64](https://temporal.download/cli/archive/latest?platform=linux&arch=arm64)
 
-Once you've downloaded the file, extract the downloaded archive and add the temporal binary to your PATH by copying it to a directory like /usr/local/bin
+Extract any downloaded archive and add the `temporal` binary to your `PATH`.
 
 ## Windows
 
-Check your machine's architecture and download the appropriate archive:
+Download from the CDN: <!-- docs/cli/setup-cli.mdx:76-78 -->
 
 - [Windows amd64](https://temporal.download/cli/archive/latest?platform=windows&arch=amd64)
 - [Windows arm64](https://temporal.download/cli/archive/latest?platform=windows&arch=arm64)
 
-Once you've downloaded the file, extract the downloaded archive and add the temporal.exe binary to your PATH.
+Extract the archive and add the `temporal.exe` binary to your `PATH`.
+
+## Docker
+
+```bash
+docker run --rm temporalio/temporal --help
+```
+
+<!-- docs/cli/setup-cli.mdx:87-89 -->
+
+## `tcld` (Temporal Cloud CLI)
+
+Needed for Cloud-connected development (managing Cloud namespaces, API keys, etc.).
+
+Homebrew:
+
+```bash
+brew install temporalio/brew/tcld
+```
+
+<!-- Source: skill-temporal-cli SKILL.md install section -->

--- a/references/core/install_cli.md
+++ b/references/core/install_cli.md
@@ -1,23 +1,23 @@
 # How to install Temporal CLI
 
-<!-- Source: docs/cli/setup-cli.mdx (Install the CLI) -->
-
 ## macOS
 
-Homebrew or CDN tarball:
+### Via homebrew
 
 ```bash
 brew install temporal
 ```
 
+### Via tarball download
+
 - [Darwin amd64](https://temporal.download/cli/archive/latest?platform=darwin&arch=amd64)
 - [Darwin arm64](https://temporal.download/cli/archive/latest?platform=darwin&arch=arm64)
 
-Extract any downloaded archive and add the `temporal` binary to your `PATH`. <!-- docs/cli/setup-cli.mdx:46 -->
+Extract any downloaded archive and add the `temporal` binary to your `PATH`.
 
 ## Linux
 
-Homebrew (if available), Snap, or CDN tarball: <!-- docs/cli/setup-cli.mdx:55-60 -->
+Homebrew (if available), Snap, or tarball download:
 
 ```bash
 brew install temporal
@@ -32,7 +32,7 @@ Extract any downloaded archive and add the `temporal` binary to your `PATH`.
 
 ## Windows
 
-Download from the CDN: <!-- docs/cli/setup-cli.mdx:76-78 -->
+Download the tarballs:
 
 - [Windows amd64](https://temporal.download/cli/archive/latest?platform=windows&arch=amd64)
 - [Windows arm64](https://temporal.download/cli/archive/latest?platform=windows&arch=arm64)
@@ -45,16 +45,12 @@ Extract the archive and add the `temporal.exe` binary to your `PATH`.
 docker run --rm temporalio/temporal --help
 ```
 
-<!-- docs/cli/setup-cli.mdx:87-89 -->
-
 ## `tcld` (Temporal Cloud CLI)
 
-Needed for Cloud-connected development (managing Cloud namespaces, API keys, etc.).
+Only needed for Cloud-connected development (managing Cloud namespaces, API keys, etc.).
 
 Homebrew:
 
 ```bash
 brew install temporalio/brew/tcld
 ```
-
-<!-- Source: skill-temporal-cli SKILL.md install section -->


### PR DESCRIPTION
## Summary

Migrates developer-facing content from `skill-temporal-cli` into the developer skill as part of retiring the CLI skill.

**New file (1):**
- `references/core/cli-workflow-commands.md` (266 lines) — CLI reference for workflow start, execute, signal, query, update, signal-with-start, result, metadata

**Enriched files (4):**
- `dev-management.md` (26→114 lines) — full `temporal server start-dev` flag table, persistence guidance, dev-to-prod recipe
- `gotchas.md` — 5 CLI gotchas (in-memory default, not-for-prod, update is a group, wait-for-stage, reapply-type)
- `install_cli.md` (25→59 lines) — CDN tarball, Docker, tcld installation
- `SKILL.md` — absorbed CLI trigger phrases, new reference entry, ops cross-reference

**Verification:**
- Grounding: all flags/enums verified against `docs/cli/workflow.mdx` and `docs/cli/server.mdx`
- No duplication with existing `patterns.md`, `interactive-workflows.md`, or `troubleshooting.md`

## Test plan

- [ ] Read `cli-workflow-commands.md` for completeness against `temporal workflow --help`
- [ ] Verify `dev-management.md` flags match `temporal server start-dev --help`
- [ ] Confirm new gotchas don't duplicate existing entries in `gotchas.md`
- [ ] Spot-check 5 inline citations against `../documentation/` source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)