### PR TITLE
Add claude code marketplace config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "temporal",
+  "owner": {
+    "name": "Temporal Technologies Inc.",
+    "url": "https://temporal.io"
+  },
+  "plugins": [
+    {
+      "name": "temporal-developer",
+      "source": "./",
+      "description": "Develop, debug, and manage Temporal applications across Python, TypeScript, Go, Java, .NET and Ruby."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "temporal-developer",
+  "version": "0.5.0",
+  "description": "Develop, debug, and manage Temporal applications across Python, TypeScript, Go, Java, .NET and Ruby.",
+  "author": {
+    "name": "Temporal Technologies Inc.",
+    "url": "https://temporal.io"
+  },
+  "homepage": "https://github.com/temporalio/skill-temporal-developer",
+  "repository": "https://github.com/temporalio/skill-temporal-developer",
+  "license": "MIT",
+  "keywords": ["temporal", "durable-execution", "workflows", "activities", "workers"],
+  "skills": ["./"]
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,29 @@ This skill is packaged as a plugin for major coding agents, which provides a sim
 
 See each repo's README for installation instructions.
 
+<details>
+<summary><b>Install the Claude Code plugin directly from this repo</b></summary>
+
+This repository ships its own Claude Code marketplace, so you can install the plugin without the separate wrapper repo. From within Claude Code:
+
+1. Add this repo as a marketplace:
+
+   ```
+   /plugin marketplace add temporalio/skill-temporal-developer
+   ```
+
+2. Install the plugin from it:
+
+   ```
+   /plugin install temporal-developer@temporal
+   ```
+
+3. Confirm the `temporal-developer` skill is available (e.g. via `/plugin` or by listing skills).
+
+To update later, re-run `/plugin marketplace update temporal` and reinstall.
+
+</details>
+
 ### Standalone Installation
 
 If you prefer to install the skill directly without the plugin wrapper:


### PR DESCRIPTION
## What was changed

Add claude code marketplace and plugin configuration.

## Why?

Is easier to share in projects that use claude and add on version control a shared `.claude/settings.json` config

## Checklist

2. How was this tested:

Before merge:
```
claude plugin marketplace add robsonpeixoto/skill-temporal-developer
claude plugin install temporal-developer@temporalio
```

After merge:
```
claude plugin marketplace add temporalio/skill-temporal-developer
claude plugin install temporal-developer@temporalio

```

3. Any docs updates needed?

On README.md explaining how to install the plugin on Claude Code.