### PR TITLE
VLN-1526: remediate unpinned-github-actions

### DIFF
--- a/.github/workflows/package-skill.yml
+++ b/.github/workflows/package-skill.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -53,14 +53,14 @@ jobs:
             -x '*.DS_Store'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: temporal-developer-skill
           path: temporal-developer-skill.zip
 
       - name: Create release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}
@@ -89,19 +89,19 @@ jobs:
     steps:
       - name: Generate token from GitHub App
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SKILL_T_DEV_APP_ID }}
           private-key: ${{ secrets.SKILL_T_DEV_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Checkout target repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ matrix.repo }}
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/skill-temporal-developer</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1526">VLN-1526</a></td></tr>
</table>

## Summary

🤠 [Deputy](https://github.com/temporalio/deputy) pinned dependencies to immutable references.

- Total refs: 4
- Pinned refs: 4

Changed references:
- `actions/checkout`: `v6` -> `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3`
- `actions/upload-artifact`: `v7` -> `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
- `softprops/action-gh-release`: `v3` -> `b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0`
- `actions/create-github-app-token`: `v3` -> `bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0`

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix