### PR TITLE
Fix Python reference guidance from issue #256

### DIFF
--- a/references/core/versioning.md
+++ b/references/core/versioning.md
@@ -104,7 +104,7 @@ Create a new workflow type (e.g., `OrderWorkflowV2`) instead of patching.
 Manage versions through Worker Deployments. Multiple Worker Deployment Versions can run simultaneously, and each version is identified by a deployment name and Build ID.
 
 > [!IMPORTANT]
-> This is the current Worker Deployment-based versioning model. Do not confuse it with the legacy Build ID-based Worker Versioning APIs, which manage compatibility sets directly and are deprecated.
+> This is the current Worker Deployment-based versioning model. Do not confuse it with the legacy Build ID-based Worker Versioning APIs, which manage compatibility sets directly. Those APIs are deprecated.
 
 ```
 Worker Deployment Version (deployment: order-service, build: abc123)
@@ -121,7 +121,7 @@ Worker Deployment Version (deployment: order-service, build: def456)
 
 **Worker Deployment Version**: A specific snapshot identified by a Worker Deployment name and a Build ID
 
-**Build ID**: The code-version component of a Worker Deployment Version (e.g., a git commit hash), not the legacy compatibility-set API
+**Build ID**: The code-version component of a Worker Deployment Version (e.g., a git commit hash)
 
 **Versioning Behaviors**:
 

--- a/references/core/versioning.md
+++ b/references/core/versioning.md
@@ -8,7 +8,7 @@ Workflow versioning allows safe deployment of code changes without breaking runn
 
 1. **Patching API** - Code-level version branching
 2. **Workflow Type Versioning** - New workflow types for incompatible changes
-3. **Worker Versioning** - Deployment-level control with Build IDs
+3. **Worker Versioning** - Deployment-level routing with Worker Deployment Versions
 
 ## Why Versioning is Needed
 
@@ -101,13 +101,16 @@ Create a new workflow type (e.g., `OrderWorkflowV2`) instead of patching.
 
 ### Concept
 
-Manage versions at deployment level using Build IDs. Multiple worker versions can run simultaneously.
+Manage versions through Worker Deployments. Multiple Worker Deployment Versions can run simultaneously, and each version is identified by a deployment name and Build ID.
+
+> [!IMPORTANT]
+> This is the current Worker Deployment-based versioning model. Do not confuse it with the legacy Build ID-based Worker Versioning APIs, which manage compatibility sets directly and are deprecated.
 
 ```
-Worker v1.0 (Build ID: abc123)
+Worker Deployment Version (deployment: order-service, build: abc123)
   └── Handles workflows started on this version
 
-Worker v2.0 (Build ID: def456)
+Worker Deployment Version (deployment: order-service, build: def456)
   └── Handles new workflows
   └── Can also handle upgraded old workflows
 ```
@@ -116,7 +119,9 @@ Worker v2.0 (Build ID: def456)
 
 **Worker Deployment**: Logical service grouping (e.g., "order-service")
 
-**Build ID**: Specific code version (e.g., git commit hash)
+**Worker Deployment Version**: A specific snapshot identified by a Worker Deployment name and a Build ID
+
+**Build ID**: The code-version component of a Worker Deployment Version (e.g., a git commit hash), not the legacy compatibility-set API
 
 **Versioning Behaviors**:
 

--- a/references/python/advanced-features.md
+++ b/references/python/advanced-features.md
@@ -152,7 +152,7 @@ Normally, your `__init__` must have no arguments. However, if you add the `@work
 class MyWorkflow:
     @workflow.init
     def __init__(self, initial_value: str) -> None:
-        # This runs only on first execution, not replay
+        # This runs when the Workflow is instantiated, including during replay
         self._value = initial_value
         self._items: list[str] = []
 

--- a/references/python/versioning.md
+++ b/references/python/versioning.md
@@ -183,6 +183,9 @@ temporal workflow list --query 'WorkflowType = "PizzaWorkflow" AND ExecutionStat
 
 Worker Versioning manages versions at the deployment level, allowing multiple Worker versions to run simultaneously.
 
+> [!IMPORTANT]
+> Use the Worker Deployment APIs described below. The older Build ID-based APIs, including `Client.get_worker_build_id_compatibility()` and `Client.update_worker_build_id_compatibility()`, manage legacy compatibility sets and are deprecated; they are not the same as Worker Deployment Versioning.
+
 ### Key Concepts
 
 **Worker Deployment**: A logical service grouping similar Workers together (e.g., "loan-processor"). All versions of your code live under this umbrella.
@@ -192,11 +195,8 @@ Worker Versioning manages versions at the deployment level, allowing multiple Wo
 ### Configuring Workers for Versioning
 
 ```python
-from temporalio.worker import Worker
-from temporalio.worker.deployment_config import (
-    WorkerDeploymentConfig,
-    WorkerDeploymentVersion,
-)
+from temporalio.common import WorkerDeploymentVersion
+from temporalio.worker import Worker, WorkerDeploymentConfig
 
 worker = Worker(
     client,
@@ -217,7 +217,7 @@ worker = Worker(
 
 - `use_worker_versioning`: Enables Worker Versioning
 - `version`: Identifies the Worker Deployment Version (deployment name + build ID)
-- Build ID: Typically a git commit hash, version number, or timestamp
+- `build_id`: The code-version component of a Worker Deployment Version, typically a git commit hash, version number, or timestamp
 
 ### PINNED vs AUTO_UPGRADE Behaviors
 

--- a/references/python/versioning.md
+++ b/references/python/versioning.md
@@ -184,7 +184,7 @@ temporal workflow list --query 'WorkflowType = "PizzaWorkflow" AND ExecutionStat
 Worker Versioning manages versions at the deployment level, allowing multiple Worker versions to run simultaneously.
 
 > [!IMPORTANT]
-> Use the Worker Deployment APIs described below. The older Build ID-based APIs, including `Client.get_worker_build_id_compatibility()` and `Client.update_worker_build_id_compatibility()`, manage legacy compatibility sets and are deprecated; they are not the same as Worker Deployment Versioning.
+> Use the Worker Deployment APIs described below. The older Build ID-based APIs, including `Client.get_worker_build_id_compatibility()` and `Client.update_worker_build_id_compatibility()`, manage legacy compatibility sets and are deprecated.
 
 ### Key Concepts
 
@@ -213,11 +213,16 @@ worker = Worker(
 )
 ```
 
-**Configuration parameters:**
+`WorkerDeploymentConfig` accepts exactly three parameters:
 
+- `version`: A `WorkerDeploymentVersion` identifying this Worker Deployment Version
 - `use_worker_versioning`: Enables Worker Versioning
-- `version`: Identifies the Worker Deployment Version (deployment name + build ID)
-- `build_id`: The code-version component of a Worker Deployment Version, typically a git commit hash, version number, or timestamp
+- `default_versioning_behavior`: Fallback `VersioningBehavior` for Workflows that do not declare one
+
+`WorkerDeploymentVersion` accepts exactly two parameters:
+
+- `deployment_name`: The logical service name (e.g., "my-service")
+- `build_id`: The code-version component, typically a git commit hash, version number, or timestamp
 
 ### PINNED vs AUTO_UPGRADE Behaviors
 

--- a/references/python/versioning.md
+++ b/references/python/versioning.md
@@ -184,7 +184,7 @@ temporal workflow list --query 'WorkflowType = "PizzaWorkflow" AND ExecutionStat
 Worker Versioning manages versions at the deployment level, allowing multiple Worker versions to run simultaneously.
 
 > [!IMPORTANT]
-> Use the Worker Deployment APIs described below. The older Build ID-based APIs, including `Client.get_worker_build_id_compatibility()` and `Client.update_worker_build_id_compatibility()`, manage legacy compatibility sets and are deprecated.
+> Use the Worker Deployment APIs described below. The older Build ID-based APIs manage legacy compatibility sets and are deprecated.
 
 ### Key Concepts
 

--- a/references/typescript/versioning.md
+++ b/references/typescript/versioning.md
@@ -148,8 +148,6 @@ After all V1 executions complete, remove the old Workflow function.
 
 Worker Versioning allows multiple Worker versions to run simultaneously, routing Workflows to specific versions without code-level patching. Workflows are pinned to the Worker Deployment Version they started on.
 
-> **Note:** Worker Versioning is currently in Public Preview. The legacy Worker Versioning API is deprecated.
-
 ### Key Concepts
 
 - **Worker Deployment**: A logical name for your application (e.g., "order-service")

--- a/references/typescript/versioning.md
+++ b/references/typescript/versioning.md
@@ -148,7 +148,7 @@ After all V1 executions complete, remove the old Workflow function.
 
 Worker Versioning allows multiple Worker versions to run simultaneously, routing Workflows to specific versions without code-level patching. Workflows are pinned to the Worker Deployment Version they started on.
 
-> **Note:** Worker Versioning is currently in Public Preview. The legacy Worker Versioning API (before 2025) will be removed from Temporal Server in March 2026.
+> **Note:** Worker Versioning is currently in Public Preview. The legacy Worker Versioning API is deprecated.
 
 ### Key Concepts
 


### PR DESCRIPTION
## Summary

- clarify that `@workflow.init` initialization runs during replay
- distinguish current Worker Deployment Versioning from deprecated Build ID compatibility-set APIs
- update the Python Worker Deployment imports to the current public API
- note that the problematic `.memory/` QA files are already absent from the packaged repository

## Validation

- `git diff --check`
- cross-checked the versioning terminology and Python imports against current Temporal documentation and SDK sources

Closes #256