### PR TITLE
Fix .NET worker cancellation example

### DIFF
--- a/references/dotnet/dotnet.md
+++ b/references/dotnet/dotnet.md
@@ -59,13 +59,20 @@ using Temporalio.Worker;
 
 var client = await TemporalClient.ConnectAsync(new("localhost:7233"));
 
+using var tokenSource = new CancellationTokenSource();
+Console.CancelKeyPress += (_, eventArgs) =>
+{
+    tokenSource.Cancel();
+    eventArgs.Cancel = true;
+};
+
 using var worker = new TemporalWorker(
     client,
     new TemporalWorkerOptions("my-task-queue")
         .AddWorkflow<GreetingWorkflow>()
         .AddAllActivities(new MyActivities()));
 
-await worker.ExecuteAsync();
+await worker.ExecuteAsync(tokenSource.Token);
 ```
 
 **Start the dev server:** Start `temporal server start-dev` in the background.

--- a/references/dotnet/dotnet.md
+++ b/references/dotnet/dotnet.md
@@ -59,13 +59,20 @@ using Temporalio.Worker;
 
 var client = await TemporalClient.ConnectAsync(new("localhost:7233"));
 
+using var tokenSource = new CancellationTokenSource();
+Console.CancelKeyPress += (_, eventArgs) =>
+{
+    tokenSource.Cancel();
+    eventArgs.Cancel = true;
+};
+
 using var worker = new TemporalWorker(
     client,
     new TemporalWorkerOptions("my-task-queue")
         .AddWorkflow<GreetingWorkflow>()
         .AddAllActivities(new MyActivities()));
 
-await worker.ExecuteAsync(() => Task.Delay(Timeout.Infinite));
+await worker.ExecuteAsync(tokenSource.Token);
 ```
 
 **Start the dev server:** Start `temporal server start-dev` in the background.

--- a/references/dotnet/dotnet.md
+++ b/references/dotnet/dotnet.md
@@ -59,20 +59,13 @@ using Temporalio.Worker;
 
 var client = await TemporalClient.ConnectAsync(new("localhost:7233"));
 
-using var tokenSource = new CancellationTokenSource();
-Console.CancelKeyPress += (_, eventArgs) =>
-{
-    tokenSource.Cancel();
-    eventArgs.Cancel = true;
-};
-
 using var worker = new TemporalWorker(
     client,
     new TemporalWorkerOptions("my-task-queue")
         .AddWorkflow<GreetingWorkflow>()
         .AddAllActivities(new MyActivities()));
 
-await worker.ExecuteAsync(tokenSource.Token);
+await worker.ExecuteAsync(() => Task.Delay(Timeout.Infinite));
 ```
 
 **Start the dev server:** Start `temporal server start-dev` in the background.


### PR DESCRIPTION
## Summary

- pass an infinite-delay task to the .NET worker quick-start example
- use the `Func<Task>` overload of `TemporalWorker.ExecuteAsync`
- keep the worker running indefinitely without requiring a cancellation token

## Validation

- compiled the complete example with .NET SDK 8.0.424 and Temporalio 1.18.0
- `git diff --check`

Closes #238
