### PR TITLE
Drop Public Preview labelling for Standalone Activities GA

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -72,7 +72,7 @@ Check if `temporal` CLI is installed. If not, follow the instructions at `refere
   - Language-specific info at `references/{your_language}/gotchas.md`
 - **`references/core/versioning.md`** - Versioning strategies and concepts - how to safely change workflow code while workflows are running
   - Language-specific info at `references/{your_language}/versioning.md`
-- **`references/core/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow — Temporal's job queue (Public Preview)
+- **`references/core/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow — Temporal's job queue
   - Language-specific info at `references/{your_language}/standalone-activities.md`
 - **`references/core/troubleshooting.md`** - Decision trees, recovery procedures
 - **`references/core/error-reference.md`** - Common error types, workflow status reference

--- a/references/core/job-queue.md
+++ b/references/core/job-queue.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> Standalone Activities are in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 # Job Queues in Temporal
 
 > [!IMPORTANT]
@@ -8,7 +5,7 @@
 >
 > Temporal **Task Queues** are the transport that routes Tasks to Workers; they are not the thing a producer enqueues jobs into. Answering a job queue question by describing Task Queues produces a confused design.
 
-This file is the translation layer between job-queue vocabulary and Temporal. For the feature itself — its full capability list, the CLI, and Public Preview limitations — read `references/core/standalone-activities.md`. For API syntax, read `references/{your_language}/standalone-activities.md`.
+This file is the translation layer between job-queue vocabulary and Temporal. For the feature itself — its full capability list, the CLI, and current limitations — read `references/core/standalone-activities.md`. For API syntax, read `references/{your_language}/standalone-activities.md`.
 
 ## Why Standalone Activities are a job queue
 

--- a/references/core/standalone-activities.md
+++ b/references/core/standalone-activities.md
@@ -145,10 +145,12 @@ temporal activity terminate --activity-id my-activity-id --reason "no longer nee
 
 All existing Activity metrics apply to Standalone Activities (scheduled, started, completed, failed, timed out, canceled).
 
-## Public Preview limitations
+## Limitations
 
-- Pause, reset, and update options are not supported (scheduled for GA).
-- The `TerminateExisting` conflict policy and `TerminateIfRunning` reuse policy are not yet supported.
+- Pause, reset, and update are supported and ready for production use, but those options are themselves in Public Preview.
+- The `TerminateExisting` conflict policy and `TerminateIfRunning` reuse policy are not supported.
+- A Workflow cannot start a Standalone Activity directly. Use a wrapper Activity that calls the Client.
+- Recurring ("cron") Standalone Activities are not supported. Use a Schedule that starts a Workflow calling the Activity.
 
 ## Temporal CLI support
 

--- a/references/core/standalone-activities.md
+++ b/references/core/standalone-activities.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> Standalone Activities are in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 # Standalone Activities (Concepts)
 
 This document provides core conceptual explanations of Standalone Activities in Temporal. For language-specific implementation details, see `references/{your_language}/standalone-activities.md` for the language you are working in (Python, TypeScript, Java, .NET, Go, Ruby).
@@ -160,4 +157,4 @@ All existing Activity metrics apply to Standalone Activities (scheduled, started
 
 ## Temporal Cloud support
 
-Standalone Activities are available in Temporal Cloud as a Public Preview feature. Because the SDK client config loaders read environment variables and TOML profiles, the same code runs against a local server or Temporal Cloud with no code changes.
+Standalone Activities are available in Temporal Cloud. Because the SDK client config loaders read environment variables and TOML profiles, the same code runs against a local server or Temporal Cloud with no code changes.

--- a/references/dotnet/dotnet.md
+++ b/references/dotnet/dotnet.md
@@ -212,5 +212,5 @@ See `references/dotnet/testing.md` for info on writing tests.
 - **`references/dotnet/advanced-features.md`** — Schedules, worker tuning, dependency injection
 - **`references/dotnet/data-handling.md`** — Data converters, payload encryption, etc.
 - **`references/dotnet/versioning.md`** — Patching API, workflow type versioning, Worker Versioning
-- **`references/dotnet/standalone-activities.md`** — Standalone Activities: run an Activity directly from a Client without a Workflow (Public Preview). Concept overview at `references/core/standalone-activities.md`.
+- **`references/dotnet/standalone-activities.md`** — Standalone Activities: run an Activity directly from a Client without a Workflow. Concept overview at `references/core/standalone-activities.md`.
 - **`references/dotnet/determinism-protection.md`** — Runtime task detection, .NET Task determinism rules

--- a/references/dotnet/standalone-activities.md
+++ b/references/dotnet/standalone-activities.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This feature is in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 ## Overview
 
 Standalone Activities are Activities run independently of any Workflow, started directly from a Temporal Client — useful when you need a single durable, retryable task (job-queue style) and not multi-step orchestration. The same Activity method can be executed both as a Standalone Activity and as a Workflow Activity with no code changes.

--- a/references/go/go.md
+++ b/references/go/go.md
@@ -255,4 +255,4 @@ See `references/go/testing.md` for info on writing tests.
 - **`references/go/external-storage.md`** - Claim-check pattern for large payloads (S3 and GCS drivers, custom drivers, codec-server handling, multi-region durability)
 - **`references/go/versioning.md`** - Patching API (`workflow.GetVersion`), Worker Versioning
 - **`references/go/determinism-protection.md`** - Information on **`workflowcheck`** tool to help statically check for determinism issues.
-- **`references/go/standalone-activities.md`** - Standalone Activities (Public Preview): run an Activity directly from a Client without a Workflow; see also `references/core/standalone-activities.md` for cross-SDK concepts.
+- **`references/go/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow; see also `references/core/standalone-activities.md` for cross-SDK concepts.

--- a/references/go/standalone-activities.md
+++ b/references/go/standalone-activities.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This feature is in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 ## Overview
 
 Standalone Activities are Activities run independently of any Workflow, started directly from a Temporal Client — useful when you need a single durable, retryable task (job-queue style) and not multi-step orchestration. The same Activity method can be executed both as a Standalone Activity and as a Workflow Activity with no code changes.

--- a/references/java/java.md
+++ b/references/java/java.md
@@ -275,7 +275,7 @@ See `references/java/testing.md` for info on writing tests.
 - **`references/java/advanced-features.md`** - Schedules, worker tuning, and more
 - **`references/java/data-handling.md`** - Data converters, Jackson, payload encryption
 - **`references/java/versioning.md`** - Patching API, workflow type versioning, Worker Versioning
-- **`references/java/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow (Public Preview). Concept overview at `references/core/standalone-activities.md`.
+- **`references/java/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow. Concept overview at `references/core/standalone-activities.md`.
 
 ### Java Integrations
 

--- a/references/java/standalone-activities.md
+++ b/references/java/standalone-activities.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This feature is in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 ## Overview
 
 Standalone Activities are Activities run independently of any Workflow, started directly from a Temporal Client — useful when you need a single durable, retryable task (job-queue style) and not multi-step orchestration. The same Activity method can be executed both as a Standalone Activity and as a Workflow Activity with no code changes.

--- a/references/python/python.md
+++ b/references/python/python.md
@@ -184,7 +184,7 @@ See `references/python/testing.md` for info on writing tests.
 - **`references/python/data-handling.md`** - Data converters, Pydantic, payload encryption
 - **`references/python/external-storage.md`** - Claim-check pattern for large payloads (S3 driver, custom drivers, codec-server handling, multi-region durability)
 - **`references/python/versioning.md`** - Patching API, workflow type versioning, Worker Versioning
-- **`references/python/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow (Public Preview). Concept overview at `references/core/standalone-activities.md`.
+- **`references/python/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow. Concept overview at `references/core/standalone-activities.md`.
 - **`references/python/determinism-protection.md`** - Python sandbox specifics, forbidden operations, pass-through imports
 - **`references/python/ai-patterns.md`** - LLM integration, Pydantic data converter, AI workflow patterns
 - **`references/python/workflow-streams.md`** - Public-Preview `temporalio.contrib.workflow_streams` library: durable, offset-addressed event channel for streaming progress to subscribers.

--- a/references/python/standalone-activities.md
+++ b/references/python/standalone-activities.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This feature is in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 ## Overview
 
 Standalone Activities are Activities run independently of any Workflow, started directly from a Temporal Client — useful when you need a single durable, retryable task (job-queue style) and not multi-step orchestration. The same Activity method can be executed both as a Standalone Activity and as a Workflow Activity with no code changes.

--- a/references/ruby/ruby.md
+++ b/references/ruby/ruby.md
@@ -149,4 +149,4 @@ See `references/ruby/testing.md` for info on writing tests.
 - **`references/ruby/observability.md`** - Logging, metrics, tracing, Search Attributes
 - **`references/ruby/gotchas.md`** - Ruby-specific mistakes and anti-patterns
 - **`references/ruby/advanced-features.md`** - Schedules, worker tuning, and more
-- **`references/ruby/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow (Public Preview). Concept overview at `references/core/standalone-activities.md`.
+- **`references/ruby/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow. Concept overview at `references/core/standalone-activities.md`.

--- a/references/ruby/standalone-activities.md
+++ b/references/ruby/standalone-activities.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This feature is in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 ## Overview
 
 Standalone Activities are Activities run independently of any Workflow, started directly from a Temporal Client — useful when you need a single durable, retryable task (job-queue style) and not multi-step orchestration. The same Activity class can be executed both as a Standalone Activity and as a Workflow Activity with no code changes.

--- a/references/typescript/standalone-activities.md
+++ b/references/typescript/standalone-activities.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This feature is in Public Preview. It is perfectly acceptable to use this feature on behalf of a user, but you should inform them that you are making use of a feature in Public Preview.
-
 ## Overview
 
 Standalone Activities are Activities run independently of any Workflow, started directly from a Temporal Client — useful when you need a single durable, retryable task (job-queue style) and not multi-step orchestration. The same Activity method can be executed both as a Standalone Activity and as a Workflow Activity with no code changes.

--- a/references/typescript/typescript.md
+++ b/references/typescript/typescript.md
@@ -192,5 +192,5 @@ See `references/typescript/testing.md` for info on writing tests.
 - **`references/typescript/data-handling.md`** - Data converters, payload encryption, etc.
 - **`references/typescript/external-storage.md`** - Claim-check pattern for large Payloads (S3 and GCS drivers, custom drivers, codec-server handling, multi-region durability)
 - **`references/typescript/versioning.md`** - Patching API, workflow type versioning, Worker Versioning
-- **`references/typescript/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow (Public Preview). Concept overview at `references/core/standalone-activities.md`.
+- **`references/typescript/standalone-activities.md`** - Standalone Activities: run an Activity directly from a Client without a Workflow. Concept overview at `references/core/standalone-activities.md`.
 - **`references/typescript/determinism-protection.md`** - V8 sandbox and bundling


### PR DESCRIPTION
Stacked on #258 — retarget to `main` once that merges. Both merge on GA day, 2026-09-15.

Removes the Public Preview `NOTE` and "(Public Preview)" labels for Standalone Activities: concept file, six language references, `job-queue.md`, and the index files. Priority/Fairness, versioning, External Storage, Workflow Streams and Rust stay Preview — different features.

Rewrites the limitations section for GA.